### PR TITLE
Prevents user from continuing a combat mission outside the initial location

### DIFF
--- a/travel.php
+++ b/travel.php
@@ -70,9 +70,18 @@ function travel() {
             $player->location = $location;
             $player->y = $target_y;
             $player->x = $target_x;
+
+            if($player->mission_id && $player->mission_stage['action_type'] == 'combat') {
+                $mission = new Mission($player->mission_id, $player);
+                if($mission->mission_type == 5) {
+                    $mission->nextStage($player->mission_stage['stage_id'] = 4);
+                    $player->mission_stage['mission_money'] /= 2;
+                    throw new Exception("Mission failed! Return to village.");
+                }
+            }
+
             $player->updateData();
         } catch(Exception $e) {
-            $system->message("You cannot travel into another village!");
             $system->message($e->getMessage());
         }
 		

--- a/travel.php
+++ b/travel.php
@@ -181,6 +181,9 @@ function travel() {
 				echo "<a href='{$system->links['mission']}'><p class='button' style='margin-top:5px;'>Go to Mission Location</p></a><br />";
 			}
 		}
+        else if($player->mission_stage['action_type'] == 'combat') {
+            echo "<h3>Warning: Attempting to travel will cancel your mission!</h3>";
+        }
 	}
 
 	echo "<span style='font-style:italic;margin-bottom:3px;display:inline-block;font-size:0.9em;'>


### PR DESCRIPTION
When attempting to move before entering combat for a mission, the mission ends as if a combat draw occurs and tells the user to go back to the village.

Halves the yen gain that they have accumulated so far when they return to the village.

Coincidentally also closes #132