### PR TITLE
Bug Fix - Prevent Survival Mission Spam in Village

### DIFF
--- a/pages/battle.php
+++ b/pages/battle.php
@@ -60,7 +60,15 @@ function battle(): bool {
 				$player->last_pvp = time();
 				$player->last_death = time();
 				$player->moveToVillage();
-				// Daily Tasks
+
+                // If player is killed during a survival mission as a result of PVP, clear the survival mission
+                if($player->mission_id != null)
+                {
+                    check_survival_missions($player->mission_id);
+                }
+
+
+                // Daily Tasks
 				foreach ($player->daily_tasks as $task) {
 					if ($task->activity == DailyTask::ACTIVITY_PVP && $task->sub_task == DailyTask::SUB_TASK_COMPLETE && !$task->complete) {
 						$task->progress++;
@@ -73,12 +81,11 @@ function battle(): bool {
 				$player->moveToVillage();
 				$player->last_pvp = time();
 
-				// Daily Tasks
-				foreach ($player->daily_tasks as $task) {
-					if ($task->activity == DailyTask::ACTIVITY_PVP && $task->sub_task == DailyTask::SUB_TASK_COMPLETE && !$task->complete) {
-						$task->progress++;
-					}
-				}
+                // If player is killed during a survival mission as a result of PVP, clear the survival mission
+                if($player->mission_id != null)
+                {
+                    check_survival_missions($player->mission_id);
+                }
 			}
 			echo "</td></tr></table>";
 			$player->battle_id = 0;
@@ -138,4 +145,25 @@ function battle(): bool {
 		scoutArea();
 	}
 	return true;
+}
+
+/**
+ * @param int $mission_id
+ * @return void
+ */
+function check_survival_missions(Int $mission_id): void
+{
+    global $system;
+    global $player;
+
+    $result = $system->query("SELECT `mission_type` FROM `missions` WHERE `mission_id`='$mission_id' LIMIT 1");
+    if ($system->db_last_num_rows == 0) {
+        return;
+    }
+    $mission_data = $system->db_fetch($result);
+
+    if ($mission_data['mission_type'] == "5") {
+        $mission = new Mission($player->mission_id, $player);
+        $mission->nextStage($player->mission_stage['stage_id'] = 4);
+    }
 }

--- a/pages/missions.php
+++ b/pages/missions.php
@@ -168,7 +168,14 @@ function runActiveMission() {
                         else if($player->mission_stage['stage_id'] > 2){
                             $player->mission_stage['stage_id'] -= 1;
                         }
-                        $mission_status = $mission->nextStage($player->mission_stage['stage_id']);
+                        if ($player->location == $player->village_location)
+                        {
+                            $mission_status = $mission->nextStage($player->mission_stage['stage_id'] = 4);
+                        }
+                        else
+                        {
+                            $mission_status = $mission->nextStage($player->mission_stage['stage_id']);
+                        }
 
                         $player->mission_stage['ai_defeated']++;
                         $player->mission_stage['mission_money'] += $money_gain;

--- a/pages/missions.php
+++ b/pages/missions.php
@@ -168,14 +168,11 @@ function runActiveMission() {
                         else if($player->mission_stage['stage_id'] > 2){
                             $player->mission_stage['stage_id'] -= 1;
                         }
-                        if ($player->location == $player->village_location)
-                        {
-                            $mission_status = $mission->nextStage($player->mission_stage['stage_id'] = 4);
-                        }
-                        else
-                        {
-                            $mission_status = $mission->nextStage($player->mission_stage['stage_id']);
-                        }
+                        if ($player->location == $player->village_location) {
+                            $player->mission_stage['stage_id'] = 4;
+                        }  
+                        
+                        $mission_status = $mission->nextStage($player->mission_stage['stage_id']);
 
                         $player->mission_stage['ai_defeated']++;
                         $player->mission_stage['mission_money'] += $money_gain;


### PR DESCRIPTION
Updated logic for survival missions to account for PVP combat while carrying out the mission. If player wins the PVP fight they can continue with the mission, however if they lose the mission will be considered a retreat and standard logic will be processed. Additionally, code was added to check if the player is supposed to be in survival combat but is somehow in the village (result of a defeat or otherwise) this was mainly added to prevent users already spamming the mission since the new check won't retroactively clear mission ids.