### PR TITLE
Fix typo in character remaining warning message.

### DIFF
--- a/pages/chat.php
+++ b/pages/chat.php
@@ -121,7 +121,7 @@ function chat() {
                 if(this.value.length >= $chat_max_post_length - 20)
                 {
                     let remaining = $chat_max_post_length - this.value.length;
-                    $('#remainingCharacters').text('Characters ramining: ' + remaining + ' out of ' + $chat_max_post_length);
+                    $('#remainingCharacters').text('Characters remaining: ' + remaining + ' out of ' + $chat_max_post_length);
                 }
                 else 
                 {

--- a/pages/privateMessages.php
+++ b/pages/privateMessages.php
@@ -191,7 +191,7 @@ class Messaging {
                             if(this.value.length >= max_length  - 20)
                             {
                                 let remaining = max_length - this.value.length;
-                                $('#remainingCharacters').text('Characters ramining: ' + remaining + ' out of ' + max_length);
+                                $('#remainingCharacters').text('Characters remaining: ' + remaining + ' out of ' + max_length);
                             }
                             else 
                             {

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -321,7 +321,7 @@ function userSettings() {
                     if(this.value.length >= $max_journal_length - 20)
                     {
                         let remaining = $max_journal_length - this.value.length;
-                        $('#remainingCharacters').text('Characters ramining: ' + remaining + ' out of ' + $max_journal_length);
+                        $('#remainingCharacters').text('Characters remaining: ' + remaining + ' out of ' + $max_journal_length);
                     }
                     else 
                     {


### PR DESCRIPTION
Fix a dumb typo in character remaining warning text. 