### PR TITLE
Regen Display Fix

### DIFF
--- a/pages/profile.php
+++ b/pages/profile.php
@@ -241,39 +241,19 @@ function userProfile() {
 				remainingtime = 60;
 
                 //Check each bar to see if regen will exceed max.
-                if(statusBars.health.current + (regen * 2) > statusBars.health.max)
-                {
-                    statusBars.health.current = statusBars.health.max;
-                    statusBars.health.next_regen = statusBars.health.max;
-                }
-                else
-                {
-                    statusBars.health.current += (regen * 2);
-                    statusBars.health.next_regen = statusBars.health.current + (regen * 2);
-                }
+                let healthRegen = regen * 2;
+                
+                statusBars.health.current = Math.min(statusBars.health.current + healthRegen, statusBars.health.max);
+                statusBars.health.next_regen = Math.min(statusBars.health.current + healthRegen, statusBars.health.max);
                 
                 //Check Chakra Bar
-                if(statusBars.chakra.current + regen > statusBars.chakra.max)
-                {
-                    statusBars.chakra.current = statusBars.chakra.max;
-                    statusBars.chakra.next_regen = statusBars.chakra.max; 
-                }
-                else
-                {
-                    statusBars.chakra.current += regen ;
-                    statusBars.chakra.next_regen = statusBars.chakra.current + regen;  
-                }
+                statusBars.chakra.current = Math.min(statusBars.chakra.current + regen, statusBars.chakra.max);
+                statusBars.chakra.next_regen = Math.min(statusBars.chakra.current + regen, statusBars.chakra.max);
+                
                 //Check Stamina Bar
-                if(statusBars.stamina.current + regen > statusBars.stamina.max)
-                {
-                    statusBars.stamina.current = statusBars.stamina.max;
-                    statusBars.stamina.next_regen = statusBars.stamina.max; 
-                }
-                else
-                {
-                    statusBars.stamina.current += regen ;
-                    statusBars.stamina.next_regen = statusBars.stamina.current + regen;  
-                }
+                statusBars.stamina.current = Math.min(statusBars.stamina.current + regen, statusBars.stamina.max);
+                statusBars.stamina.next_regen = Math.min(statusBars.stamina.current + regen, statusBars.stamina.max);
+                
                 
                 //Update Health Bar
                 $('#health').html((statusBars.health.current === statusBars.health.max)? statusBars.health.current.toFixed(2) + '/' + statusBars.health.max.toFixed(2) : statusBars.health.current.toFixed(2) + '/' + statusBars.health.max.toFixed(2) + '-> <b style=\'color: green\'>' + statusBars.health.next_regen.toFixed(2) + '</b>');
@@ -296,7 +276,11 @@ function userProfile() {
 		//can't figure out why? its like the Regen changes every other minute in intervals or it doubles
 		//can't find the error with my script
 		//can't seem to find out where the error is, need help.
-
+		
+		function updateBarValue(bar)
+		{
+            
+		}
 		</script>
 		";
 

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -235,6 +235,7 @@ function userProfile() {
                     if(statusBars[bar][0] + (regen * 2) > statusBars[bar][1])
                     {
                         statusBars[bar][0] = statusBars[bar][1];
+                        statusBars[bar][2] = statusBars[bar][1];
                     }
                     else
                     {
@@ -245,6 +246,7 @@ function userProfile() {
                 else if (statusBars[bar][0] + regen > statusBars[bar][1])
                 {
                     statusBars[bar][0] = statusBars[bar][1];
+                    statusBars[bar][2] = statusBars[bar][1];
                 }
                 else 
                 {

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -234,7 +234,7 @@ function userProfile() {
 		setInterval(() => 
 		{
             
-			$('#regentimer').text(remainingtime); //minus 1 to compensate for lag
+			document.getElementById('regentimer').innerHTML = remainingtime; //minus 1 to compensate for lag
 
 
 			if(remainingtime <= 0){

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -212,55 +212,80 @@ function userProfile() {
 		<script>
 		var remainingtime = " . (59 - $time_since_last_regen) . ";
         var statusBars = {
-            health: [{$player->health}, {$player->max_health}, 0],         
-            chakra: [{$player->chakra}, {$player->max_chakra}, 0],
-            stamina: [{$player->stamina}, {$player->max_stamina}, 0],     
+            health: {
+                current: {$player->health}, 
+                max: {$player->max_health},
+                next_regen: 0
+            },         
+            chakra: {
+                current: {$player->chakra}, 
+                max: {$player->max_chakra}, 
+                next_regen: 0
+            },
+            stamina: {
+                current: {$player->stamina},
+                max: {$player->max_stamina},
+                next_regen: 0 
+            }
         };
 
 		var regen = {$player->regen_rate} + {$player->regen_boost}; //no regen cut
 
-		setInterval(() => {
-
+		setInterval(() => 
+		{
+            
 			$('#regentimer').text(remainingtime); //minus 1 to compensate for lag
 
 
 			if(remainingtime <= 0){
 				remainingtime = 60;
 
-			//update health amounts / bars
-			for (const bar in statusBars)
-			{            
-                if(bar === 'health')
+                //Check each bar to see if regen will exceed max.
+                if(statusBars.health.current + (regen * 2) > statusBars.health.max)
                 {
-                    if(statusBars[bar][0] + (regen * 2) > statusBars[bar][1])
-                    {
-                        statusBars[bar][0] = statusBars[bar][1];
-                        statusBars[bar][2] = statusBars[bar][1];
-                    }
-                    else
-                    {
-                        statusBars[bar][0] += (regen * 2);
-                        statusBars[bar][2] =  statusBars[bar][0] + (regen * 2);
-                    }                                
+                    statusBars.health.current = statusBars.health.max;
+                    statusBars.health.next_regen = statusBars.health.max;
                 }
-                else if (statusBars[bar][0] + regen > statusBars[bar][1])
+                else
                 {
-                    statusBars[bar][0] = statusBars[bar][1];
-                    statusBars[bar][2] = statusBars[bar][1];
+                    statusBars.health.current += (regen * 2);
+                    statusBars.health.next_regen = statusBars.health.current + (regen * 2);
                 }
-                else 
+                
+                //Check Chakra Bar
+                if(statusBars.chakra.current + regen > statusBars.chakra.max)
                 {
-                    statusBars[bar][0] += regen;
-                    statusBars[bar][2] =  statusBars[bar][0] + regen;
+                    statusBars.chakra.current = statusBars.chakra.max;
+                    statusBars.chakra.next_regen = statusBars.chakra.max; 
                 }
-                //console.log(bar, statusBars[bar]);
-                if(bar.startsWith('max')) continue;
-                $('#' + bar).html((statusBars[bar][0] == statusBars[bar][1])? statusBars[bar][0].toFixed(2) + '/' + statusBars[bar][1].toFixed(2) : statusBars[bar][0].toFixed(2) + '/' + statusBars[bar][1].toFixed(2) + '-> <b style=\'color: green\'>' + statusBars[bar][2].toFixed(2) + '</b>');
-			    $('#' + bar + 'bar').val(statusBars[bar][0]);  
-            };
-            
-
-			
+                else
+                {
+                    statusBars.chakra.current += regen ;
+                    statusBars.chakra.next_regen = statusBars.chakra.current + regen;  
+                }
+                //Check Stamina Bar
+                if(statusBars.stamina.current + regen > statusBars.stamina.max)
+                {
+                    statusBars.stamina.current = statusBars.stamina.max;
+                    statusBars.stamina.next_regen = statusBars.stamina.max; 
+                }
+                else
+                {
+                    statusBars.stamina.current += regen ;
+                    statusBars.stamina.next_regen = statusBars.stamina.current + regen;  
+                }
+                
+                //Update Health Bar
+                $('#health').html((statusBars.health.current === statusBars.health.max)? statusBars.health.current.toFixed(2) + '/' + statusBars.health.max.toFixed(2) : statusBars.health.current.toFixed(2) + '/' + statusBars.health.max.toFixed(2) + '-> <b style=\'color: green\'>' + statusBars.health.next_regen.toFixed(2) + '</b>');
+                $('#healthbar').val(statusBars.health.current);
+                
+                //Update Chakra Bar
+                $('#chakra').html((statusBars.chakra.current === statusBars.chakra.max)? statusBars.chakra.current.toFixed(2) + '/' + statusBars.chakra.max.toFixed(2) : statusBars.chakra.current.toFixed(2) + '/' + statusBars.chakra.max.toFixed(2) + '-> <b style=\'color: green\'>' + statusBars.chakra.next_regen.toFixed(2) + '</b>');
+                $('#chakrabar').val(statusBars.chakra.current);	
+                
+                //Update Stamina Bar
+                $('#stamina').html((statusBars.stamina.current === statusBars.stamina.max)? statusBars.stamina.current.toFixed(2) + '/' + statusBars.stamina.max.toFixed(2) : statusBars.stamina.current.toFixed(2) + '/' + statusBars.stamina.max.toFixed(2) + '-> <b style=\'color: green\'>' + statusBars.stamina.next_regen.toFixed(2) + '</b>');
+                $('#staminabar').val(statusBars.stamina.current);	
 			}
 
 			remainingtime--;

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -227,10 +227,10 @@ function userProfile() {
 			if(remainingtime <= 0){
 				remainingtime = 60;
 
-				if((health + regen) >= max_health){
+				if((health + (regen * 2)) >= max_health){
 					health = max_health;
 				} else {
-					health += regen; //health ignores regen boost
+					health += regen * 2; //health ignores regen boost
 				}
 
 				if((chakra + regen) >= max_chakra){

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -168,11 +168,12 @@ function userProfile() {
             $regen_cut = round(($player->regen_rate + $player->regen_boost) * 0.7, 1);
         }
 
-        $health_after_regen = ($player->health + ($player->regen_rate + $player->regen_boost - $regen_cut) * 2 > $player->max_health)? $player->max_health : $player->health + (($player->regen_rate + $player->regen_boost - $regen_cut) * 2);
-        $chakra_after_regen = ($player->chakra + ($player->regen_rate + $player->regen_boost - $regen_cut) > $player->max_chakra)? $player->max_chakra : $player->chakra + ($player->regen_rate + $player->regen_boost - $regen_cut);
-        $stamina_after_regen = ($player->stamina + ($player->regen_rate + $player->regen_boost - $regen_cut) > $player->max_stamina)? $player->max_stamina : $player->stamina + ($player->regen_rate + $player->regen_boost - $regen_cut);
+        $healthRegen = ($player->regen_rate + $player->regen_boost - $regen_cut) * 2;
+        $standardRegen = $player->regen_rate + $player->regen_boost - $regen_cut;
 
-        $total_regen_rate = $player->regen_rate + $player->regen_boost - $regen_cut;
+        $health_after_regen = min($player->health + $healthRegen, $player->max_health);
+        $chakra_after_regen = min($player->chakra + $standardRegen, $player->max_chakra);
+        $stamina_after_regen = min($player->stamina + $standardRegen, $player->max_stamina);
 
         echo "<td style='width:50%;'>
 		<label style='width:6.7em;' for='healthbar'>Health:</label>" .
@@ -197,7 +198,7 @@ function userProfile() {
 
         if($player->regen_boost) {
             echo " (+" . $player->regen_boost . ") " . ($regen_cut ? "<span style='color:#8A0000;'>(-{$regen_cut})</span> " : "") .
-                "-> <span style='color:#00C000;'>" . ($total_regen_rate) . "</span>";
+                "-> <span style='color:#00C000;'>" . ($standardRegen) . "</span>";
         }
         else if(isset($regen_cut)) {
 
@@ -256,15 +257,18 @@ function userProfile() {
                 
                 
                 //Update Health Bar
-                $('#health').html((statusBars.health.current === statusBars.health.max)? statusBars.health.current.toFixed(2) + '/' + statusBars.health.max.toFixed(2) : statusBars.health.current.toFixed(2) + '/' + statusBars.health.max.toFixed(2) + '-> <b style=\'color: green\'>' + statusBars.health.next_regen.toFixed(2) + '</b>');
+                const currentAndMaxHealth = statusBars.health.current.toFixed(2) + '/' + statusBars.health.max.toFixed(2);
+                $('#health').html(currentAndMaxHealth.concat((statusBars.health.current !== statusBars.health.max) ? ('-> <b style=\'color: green\'>' + statusBars.health.next_regen.toFixed(2) + '</b>') : ''));
                 $('#healthbar').val(statusBars.health.current);
                 
                 //Update Chakra Bar
-                $('#chakra').html((statusBars.chakra.current === statusBars.chakra.max)? statusBars.chakra.current.toFixed(2) + '/' + statusBars.chakra.max.toFixed(2) : statusBars.chakra.current.toFixed(2) + '/' + statusBars.chakra.max.toFixed(2) + '-> <b style=\'color: green\'>' + statusBars.chakra.next_regen.toFixed(2) + '</b>');
+                 const currentAndMaxChakra = statusBars.chakra.current.toFixed(2) + '/' + statusBars.chakra.max.toFixed(2);
+                $('#chakra').html(currentAndMaxChakra.concat((statusBars.chakra.current !== statusBars.chakra.max)? ('-> <b style=\'color: green\'>' + statusBars.chakra.next_regen.toFixed(2) + '</b>') : ''));
                 $('#chakrabar').val(statusBars.chakra.current);	
                 
                 //Update Stamina Bar
-                $('#stamina').html((statusBars.stamina.current === statusBars.stamina.max)? statusBars.stamina.current.toFixed(2) + '/' + statusBars.stamina.max.toFixed(2) : statusBars.stamina.current.toFixed(2) + '/' + statusBars.stamina.max.toFixed(2) + '-> <b style=\'color: green\'>' + statusBars.stamina.next_regen.toFixed(2) + '</b>');
+                const currentAndMaxStamina = statusBars.stamina.current.toFixed(2) + '/' + statusBars.stamina.max.toFixed(2);
+                $('#stamina').html(currentAndMaxStamina.concat((statusBars.stamina.current !== statusBars.stamina.max)? ('-> <b style=\'color: green\'>' + statusBars.stamina.next_regen.toFixed(2) + '</b>') : ''));
                 $('#staminabar').val(statusBars.stamina.current);	
 			}
 

--- a/pages/profile.php
+++ b/pages/profile.php
@@ -169,7 +169,7 @@ function userProfile() {
         }
 
         $health_after_regen = ($player->health + ($player->regen_rate + $player->regen_boost - $regen_cut) * 2 > $player->max_health)? $player->max_health : $player->health + (($player->regen_rate + $player->regen_boost - $regen_cut) * 2);
-        $chakra_after_regen = ($player->chakra + ($player->regen_rate + $player->regen_boost - $regen_cut) > $player->max_chakra)? $player->max_chakra : $player-chakra + ($player->regen_rate + $player->regen_boost - $regen_cut);
+        $chakra_after_regen = ($player->chakra + ($player->regen_rate + $player->regen_boost - $regen_cut) > $player->max_chakra)? $player->max_chakra : $player->chakra + ($player->regen_rate + $player->regen_boost - $regen_cut);
         $stamina_after_regen = ($player->stamina + ($player->regen_rate + $player->regen_boost - $regen_cut) > $player->max_stamina)? $player->max_stamina : $player->stamina + ($player->regen_rate + $player->regen_boost - $regen_cut);
 
         $total_regen_rate = $player->regen_rate + $player->regen_boost - $regen_cut;


### PR DESCRIPTION
#217 - This isn't actually a bug, the server side code for applying regen actually applies 2:1 for health and a 1:1 the other stats. The display refresh code doesn't account for this thus it appears that you are getting regen twice for health except it's just on page refresh it properly pulls the value from the player object. 