### PR TITLE
Cast Speed evasion text gender fix.

### DIFF
--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -416,14 +416,18 @@ class BattleManager {
             [
                 '[player]',
                 '[opponent]',
-                '[gender]',
-                '[gender2]'
+                '[attackerGender]',
+                '[attackerGender2]',
+                '[targetGender]',
+                '[targetGender2]'
             ],
             [
                 $attacker->getName(),
                 $target->getName(),
                 $attacker->getSingularPronoun(),
                 $attacker->getPossessivePronoun(),
+                $target->getSingularPronoun(),
+                $target->getPossessivePronoun(),
             ],
             $text
         );
@@ -925,7 +929,7 @@ class BattleManager {
                     $collision_text .= "[player] swiftly evaded " . ($damage_reduction * 100) . "% of [opponent]'s damage!";
                 }
                 else {
-                    $collision_text .= "[player] cast [gender2] jutsu before [opponent] cast, negating " .
+                    $collision_text .= "[player] cast [attackerGender2] jutsu before [opponent] cast, negating " .
                         ($damage_reduction * 100) . "% of [opponent]'s damage!";
                 }
             }
@@ -947,7 +951,7 @@ class BattleManager {
                     $collision_text .= "[opponent] swiftly evaded " . ($damage_reduction * 100) . "% of [player]'s damage!";
                 }
                 else {
-                    $collision_text .= "[opponent] cast [gender2] jutsu before [player] cast, negating " .
+                    $collision_text .= "[opponent] cast [targetGender2] jutsu before [player] cast, negating " .
                         ($damage_reduction * 100) . "% of [player]'s damage!";
                 }
             }

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -416,8 +416,8 @@ class BattleManager {
             [
                 '[player]',
                 '[opponent]',
-                '[attackerGender]',
-                '[attackerGender2]',
+                '[gender]',
+                '[gender2]',
                 '[targetGender]',
                 '[targetGender2]'
             ],

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -929,7 +929,7 @@ class BattleManager {
                     $collision_text .= "[player] swiftly evaded " . ($damage_reduction * 100) . "% of [opponent]'s damage!";
                 }
                 else {
-                    $collision_text .= "[player] cast [attackerGender2] jutsu before [opponent] cast, negating " .
+                    $collision_text .= "[player] cast [gender2] jutsu before [opponent] cast, negating " .
                         ($damage_reduction * 100) . "% of [opponent]'s damage!";
                 }
             }


### PR DESCRIPTION
BattleManager.parseCombatText now takes into account separate gender values for attacker/target.

Addresses bug where evasion battle text pronoun varies based on which fighter initiates combat.
e.g. [male] attacks [female]: "[female] cast her jutsu before..."
e.g. [female] attacks [male]: "[female] cast his jutsu before..."