### PR TITLE
Enable cripple effect

### DIFF
--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -83,6 +83,7 @@ class BattleEffectsManager {
             case 'cast_speed_boost':
             case 'speed_nerf':
             case 'cast_speed_nerf':
+            case 'cripple':
                 // No changes needed to base number, calculated in applyPassiveEffects
                 break;
             case 'intelligence_boost':


### PR DESCRIPTION
Adds cripple to the `BattleEffectManager.setEffect()` effect list. 
Previously unlisted and defaults to `$apply_effect = false;`

Users report this was working previously, I'm not sure if something else broke at some point but this is the apparent fix. 