### PR TITLE
Adjust bloodline stat calculations for transparency

### DIFF
--- a/classes/Bloodline.php
+++ b/classes/Bloodline.php
@@ -50,7 +50,7 @@ class Bloodline {
 
         $this->raw_passive_boosts = $bloodline_data['passive_boosts'];
         $this->raw_combat_boosts = $bloodline_data['combat_boosts'];
-        
+
         $this->base_jutsu = [];
         $this->jutsu = [];
         $jutsu_data = $bloodline_data['jutsu'];
@@ -259,15 +259,27 @@ class Bloodline {
      * @return float
      */
     private function offenseToBloodlineRatio(int $offense_skill, int $bloodline_skill): float {
-        $bloodline_skill += 10;
+        $ratio_max = 1.0;
+        $ratio_min = 0.75;
 
-        $offense_to_bloodline = round($offense_skill / $bloodline_skill, 3);
-        if($offense_to_bloodline > 1.0) {
-            $offense_to_bloodline = 1.0;
+        // Adjust to use invested skill only
+        $bloodline_skill -= self::BASE_BLOODLINE_SKILL;
+
+        // Handle case with no skill investment
+        if ($bloodline_skill <= 0) {
+            $offense_to_bloodline = $ratio_max;
         }
-        else if($offense_to_bloodline < 0.75) {
-            $offense_to_bloodline = 0.75;
+
+        else {
+            $offense_to_bloodline = round($offense_skill / $bloodline_skill, 3);
+            if($offense_to_bloodline > $ratio_max) {
+                $offense_to_bloodline = $ratio_max;
+            }
+            else if($offense_to_bloodline < $ratio_min) {
+                $offense_to_bloodline = $ratio_min;
+            }
         }
+
         return $offense_to_bloodline;
     }
 
@@ -370,7 +382,7 @@ class Bloodline {
         // Insert new row
         if($system->db_last_num_rows == 0) {
             $query = "INSERT INTO `user_bloodlines` (`user_id`, `bloodline_id`, `name`, `passive_boosts`, `combat_boosts`, `jutsu`)
-			VALUES ('$user_id', '$bloodline_id', '{$user_bloodline['name']}', '{$user_bloodline['passive_boosts']}', 
+			VALUES ('$user_id', '$bloodline_id', '{$user_bloodline['name']}', '{$user_bloodline['passive_boosts']}',
 			'{$user_bloodline['combat_boosts']}', '{$user_bloodline['jutsu']}')";
         }
 
@@ -400,9 +412,9 @@ class Bloodline {
                 $new_bloodline_skill -= $bloodline_skill_reduction;
             }
 
-            $query = "UPDATE `users` SET 
-            `bloodline_id`='$bloodline_id', 
-            `bloodline_name`='{$bloodline['name']}', 
+            $query = "UPDATE `users` SET
+            `bloodline_id`='$bloodline_id',
+            `bloodline_name`='{$bloodline['name']}',
             `bloodline_skill`='{$new_bloodline_skill}',
             `exp`='{$new_exp}'
 			WHERE `user_id`='$user_id' LIMIT 1";

--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -211,10 +211,10 @@ class BattleEffectsManager {
             $target->genjutsu_boost += $effect->effect_amount;
         }
         else if($effect->effect == 'cast_speed_boost') {
-            $target->cast_speed_boost += ($target->cast_speed + $target->bloodline_cast_speed_boost) * ($effect->effect_amount / 100);
+            $target->cast_speed_boost += $target->getCastSpeed(true) * ($effect->effect_amount / 100);
         }
         else if($effect->effect == 'speed_boost' or $effect->effect == 'lighten') {
-            $target->speed_boost += ($target->speed + $target->bloodline_speed_boost) * ($effect->effect_amount / 100);
+            $target->speed_boost += $target->getSpeed(true) * ($effect->effect_amount / 100);
         }
         else if($effect->effect == 'intelligence_boost') {
             $target->intelligence_boost += $effect->effect_amount;
@@ -251,11 +251,11 @@ class BattleEffectsManager {
             $target->genjutsu_nerf += $effect_amount;
         }
         else if($effect->effect == 'speed_nerf' or $effect->effect == 'cripple') {
-            $target->speed_nerf += ($target->speed + $target->bloodline_speed_boost) * ($effect->effect_amount / 100);
-            $target->cast_speed_nerf += ($target->cast_speed + $target->bloodline_cast_speed_boost) * ($effect->effect_amount / 100);
+            $target->speed_nerf += $target->getSpeed(true) * ($effect->effect_amount / 100);
+            $target->cast_speed_nerf += $target->getCastSpeed(true) * ($effect->effect_amount / 100);
 
-            $target->speed_nerf = min($target->speed_nerf, ($target->speed + $target->bloodline_speed_boost) * self::MAX_SPEED_REDUCTION);
-            $target->cast_speed_nerf = min($target->cast_speed_nerf, ($target->cast_speed + $target->bloodline_cast_speed_boost) * self::MAX_SPEED_REDUCTION);
+            $target->speed_nerf = min($target->speed_nerf, $target->getSpeed(true) * self::MAX_SPEED_REDUCTION);
+            $target->cast_speed_nerf = min($target->cast_speed_nerf, $target->getCastSpeed(true) * self::MAX_SPEED_REDUCTION);
         }
         else if($effect->effect == 'intelligence_nerf' or $effect->effect == 'daze') {
             $target->intelligence_nerf += $effect_amount;

--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -211,10 +211,10 @@ class BattleEffectsManager {
             $target->genjutsu_boost += $effect->effect_amount;
         }
         else if($effect->effect == 'cast_speed_boost') {
-            $target->cast_speed_boost += $target->cast_speed * ($effect->effect_amount / 100);
+            $target->cast_speed_boost += ($target->cast_speed + $target->bloodline_cast_speed_boost) * ($effect->effect_amount / 100);
         }
         else if($effect->effect == 'speed_boost' or $effect->effect == 'lighten') {
-            $target->speed_boost += $target->speed * ($effect->effect_amount / 100);
+            $target->speed_boost += ($target->speed + $target->bloodline_speed_boost) * ($effect->effect_amount / 100);
         }
         else if($effect->effect == 'intelligence_boost') {
             $target->intelligence_boost += $effect->effect_amount;
@@ -251,11 +251,11 @@ class BattleEffectsManager {
             $target->genjutsu_nerf += $effect_amount;
         }
         else if($effect->effect == 'speed_nerf' or $effect->effect == 'cripple') {
-            $target->speed_nerf += $target->speed * ($effect->effect_amount / 100);
-            $target->cast_speed_nerf += $target->cast_speed * ($effect->effect_amount / 100);
+            $target->speed_nerf += ($target->speed + $target->bloodline_speed_boost) * ($effect->effect_amount / 100);
+            $target->cast_speed_nerf += ($target->cast_speed + $target->bloodline_cast_speed_boost) * ($effect->effect_amount / 100);
 
-            $target->speed_nerf = min($target->speed_nerf, $target->speed * self::MAX_SPEED_REDUCTION);
-            $target->cast_speed_nerf = min($target->cast_speed_nerf, $target->cast_speed * self::MAX_SPEED_REDUCTION);
+            $target->speed_nerf = min($target->speed_nerf, ($target->speed + $target->bloodline_speed_boost) * self::MAX_SPEED_REDUCTION);
+            $target->cast_speed_nerf = min($target->cast_speed_nerf, ($target->cast_speed + $target->bloodline_cast_speed_boost) * self::MAX_SPEED_REDUCTION);
         }
         else if($effect->effect == 'intelligence_nerf' or $effect->effect == 'daze') {
             $target->intelligence_nerf += $effect_amount;

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -63,8 +63,8 @@ abstract class Fighter {
 
     public array $bloodline_offense_boosts;
     public array $bloodline_defense_boosts;
-    public int $bloodline_cast_speed_boost = 0;
-    public int $bloodline_speed_boost = 0;
+    public float $bloodline_cast_speed_boost = 0;
+    public float $bloodline_speed_boost = 0;
 
     public string $gender;
 
@@ -387,6 +387,13 @@ abstract class Fighter {
         return $damage;
     }
 
+    public function getCastSpeed(bool $include_bloodline = false): float {
+        return $include_bloodline ? $this->cast_speed + $this->bloodline_cast_speed_boost : $this->cast_speed;
+    }
+
+    public function getSpeed(bool $include_bloodline = false): float {
+        return $include_bloodline ? $this->speed + $this->bloodline_speed_boost : $this->speed;
+    }
 
     // Actions
     abstract public function useJutsu(Jutsu $jutsu);

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -63,6 +63,8 @@ abstract class Fighter {
 
     public array $bloodline_offense_boosts;
     public array $bloodline_defense_boosts;
+    public int $bloodline_cast_speed_boost = 0;
+    public int $bloodline_speed_boost = 0;
 
     public string $gender;
 
@@ -142,9 +144,11 @@ abstract class Fighter {
                         break;
 
                     case 'cast_speed_boost':
+                        $this->bloodline_cast_speed_boost += $effect['effect_amount'];
                         $this->cast_speed_boost += $effect['effect_amount'];
                         break;
                     case 'speed_boost':
+                        $this->bloodline_speed_boost += $effect['effect_amount'];
                         $this->speed_boost += $effect['effect_amount'];
                         break;
                     case 'intelligence_boost':
@@ -190,7 +194,7 @@ abstract class Fighter {
             return 'their';
         }
     }
-    
+
     #[Pure]
     public function getDebuffResist(): float {
         $willpower = ($this->willpower + $this->willpower_boost - $this->willpower_nerf);


### PR DESCRIPTION
Suggested changes: 
- Simplifies bloodline/offense calculation so that players need only keep bloodline and offense skills equal for optimal stat allocation rather than keeping bloodline stat exactly 110 points ahead. 
- Factors in bloodline speed/cspeed bonus for speed buff/nerf calculations. Bloodline speed bonuses being immutable is interesting but unintuitive. It also creates balance problems, particularly when speed-focused players benefit less from the use of speed boosts.