### PR TITLE
Speed Rebalance

### DIFF
--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -9,8 +9,8 @@ require_once __DIR__ . '/BattleAttack.php';
 require_once __DIR__ . '/LegacyFighterAction.php';
 
 class BattleManager {
-    const SPEED_DAMAGE_REDUCTION_RATIO = 0.4;
-    const CAST_SPEED_DAMAGE_REDUCTION_RATIO = 0.4;
+    const SPEED_DAMAGE_REDUCTION_RATIO = 0.47;
+    const CAST_SPEED_DAMAGE_REDUCTION_RATIO = 0.47;
     const MAX_EVASION_DAMAGE_REDUCTION = 0.35;
 
     private System $system;

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -10,7 +10,7 @@ abstract class Fighter {
     const BLOODLINE_OFFENSE_RATIO = self::SKILL_OFFENSE_RATIO * 0.8;
     const BLOODLINE_DEFENSE_MULTIPLIER = 35;
 
-    const SPEED_OFFENSE_RATIO = 0.35;
+    const SPEED_OFFENSE_RATIO = 0.25;
 
     const MIN_RAND = 33;
     const MAX_RAND = 36;

--- a/templates/sensei_exam.php
+++ b/templates/sensei_exam.php
@@ -56,7 +56,7 @@
                 <p class="question_label">How much speed is required to reach maximum evasion (35%)?</p>
                 <div><input type="radio" name="question4" value="4a" checked/> <label>+50%</label></div>
                 <div><input type="radio" name="question4" value="4b" /> <label>+66.6%</label></div>
-                <div><input type="radio" name="question4" value="4c" /> <label>+87.5%</label></div>
+                <div><input type="radio" name="question4" value="4c" /> <label>+75%</label></div>
                 <div><input type="radio" name="question4" value="4d" /> <label>+100%</label></div>
                 <p class="question_label">Which of the following jutsu has the greatest total power?</p>
                 <div><input type="radio" name="question5" value="5a" checked/> <label>3.5 Base Power, lv100 - Shop Jutsu</label></div>


### PR DESCRIPTION
Prior speed change before was calculated at a 4% increase in damage for balance builds and 10% increase in damage for speed builds. New change equates to a 0% increase in damage for balance builds and a 6% increase in damage for speed builds (over the original baseline before prior changes).

Speed to Offense Ratio: 0.35 -> 0.25 (reverting prior change)
Evasion Ratio: 0.4 -> 0.47
Percent required to reach maximum evasion: 87.5% -> 75%

Original Speed Build:
50k Bloodline -> 60000 Offense
50k Offense Stat -> 50000 Offense
150k Speed Stat -> 37500 Offense
Total: 147500

0.25 -> 0.35 Buffed Speed Build (Old):
50k Bloodline -> 60000 Offense
50k Offense Stat -> 50000 Offense
150k Speed Stat -> 52500 Offense
Total: 162500 (+10% total, +6% over Balance)

New Speed Build:
55k Bloodline -> 66000 Offense
55k Offense Stat -> 55000 Offense
140k Speed Stat -> 35000 Offense
156000 (+6% total, +6% over Balance)

Note: Using a maximum speed build in the example above to visualize the most significant change possible for a single build. 