### PR TITLE
Added Eight Trigram

### DIFF
--- a/classes/ForbiddenSeal.php
+++ b/classes/ForbiddenSeal.php
@@ -46,7 +46,8 @@ class ForbiddenSeal {
     public static array $forbidden_seal_names = array(
         0 => '',
         1 => 'Twin Sparrow Seal',
-        2 => 'Four Dragon Seal'
+        2 => 'Four Dragon Seal',
+        3 => 'Eight Trigram Seal'
     );
     public static array $benefits = array (
         0 => [
@@ -175,6 +176,54 @@ class ForbiddenSeal {
             'stat_transfer_boost' => 5,
             'extra_stat_transfer_points_per_ak' => 100,
             'max_battle_history_view' => 20,
+            'free_transfer_bonus' => 50,
+            'bonus_pve_reputation' => 1,
+        ],
+        3 => [
+            'regen_boost' => 20, //Report in whole percentages (20 will be .2 bonus)
+            'name_colors' => [
+                'blue' => 'blue',
+                'pink' => 'pink',
+            ],
+            'name_color_display' => 'Blue/Pink', //Premium page desc display only
+            'avatar_size' => 200,
+            'avatar_size_display' => '200x200', //Premium page display only.
+            'avatar_filesize' => self::ONE_MEGABYTE * 2,
+            'avatar_styles' => [
+                'avy_none' => 'none',
+                'avy_round' => 'circle',
+                'avy_three-point' => 'triangle',
+                'avy_three-point-inverted' => 'triange inverted',
+                'avy_four-point' => 'square',
+                'avy_four-point-90' => 'diamond',
+                'avy_four-point-oblique' => 'oblique',
+                'avy_five-point' => 'pentagon',
+                'avy_six-point' => 'hexagon',
+                'avy_six-point-long' => 'crystal',
+                //'avy_six-point-long-reverse' => 'crystal reverse',
+                'avy_eight-point' => 'octagon',
+                'avy_eight-point-wide' => 'octagon wide',
+                'avy_nine-point' => 'nonagon',
+                'avy_twelve-point' => 'cross',
+            ],
+            'logout_timer' => System::LOGOUT_LIMIT,
+            'inbox_size' => 75,
+            'journal_size' => 3500,
+            'journal_image_x' => 600,
+            'journal_image_y' => 600,
+            'journal_image_display' => '600x600', //Premium page display only.
+            'chat_post_size' => 450,
+            'pm_size' => 1500,
+            'extra_jutsu_equips' => 1,
+            'extra_weapon_equips' => 1,
+            'extra_armor_equips' => 1,
+            'long_training_time' => 1.5,
+            'long_training_gains' => 2.2,
+            'extended_training_time' => 2,
+            'extended_training_gains' => 3,
+            'stat_transfer_boost' => 6,
+            'extra_stat_transfer_points_per_ak' => 125,
+            'max_battle_history_view' => 50,
             'free_transfer_bonus' => 50,
             'bonus_pve_reputation' => 1,
         ]

--- a/classes/ForbiddenSeal.php
+++ b/classes/ForbiddenSeal.php
@@ -47,7 +47,7 @@ class ForbiddenSeal {
         0 => '',
         1 => 'Twin Sparrow Seal',
         2 => 'Four Dragon Seal',
-        3 => 'Eight Trigram Seal'
+        3 => 'Eight Deities Seal'
     );
     public static array $benefits = array (
         0 => [
@@ -180,7 +180,7 @@ class ForbiddenSeal {
             'bonus_pve_reputation' => 1,
         ],
         3 => [
-            'regen_boost' => 20, //Report in whole percentages (20 will be .2 bonus)
+            'regen_boost' => 25, //Report in whole percentages (20 will be .2 bonus)
             'name_colors' => [
                 'blue' => 'blue',
                 'pink' => 'pink',

--- a/classes/PremiumShopManager.php
+++ b/classes/PremiumShopManager.php
@@ -15,6 +15,9 @@ class PremiumShopManager {
     const EXCHANGE_MIN_YEN_PER_AK = 1.0;
     const EXCHANGE_MAX_YEN_PER_AK = 20.0;
 
+    const TIER_THREE_SALE_END = '2023-11-30';
+    const SALE_REFUND_RATE = 50;
+
     public System $system;
     public User $player;
 
@@ -42,6 +45,30 @@ class PremiumShopManager {
         $this->initStatTransferVars();
     }
 
+    ///TEMPORARY SALE LOGIC
+    public function tierThreeSaleActive(): bool {
+        $sale_end = new DateTimeImmutable(self::TIER_THREE_SALE_END);
+        $current_time = new DateTimeImmutable();
+
+        return $current_time < $sale_end;
+    }
+
+    public function saleTimeRemaining(): int {
+        $sale_end = new DateTimeImmutable(self::TIER_THREE_SALE_END);
+        return $sale_end->getTimestamp() - time();
+    }
+
+    public function loadTierThreeSalePrices($current_seal_level): void {
+        if($this->tierThreeSaleActive() && ($current_seal_level == 0 || $current_seal_level == 3)) {
+            $this->costs['forbidden_seal'][3][60] -= 5;
+            $this->costs['forbidden_seal'][3][90] -= 15;
+        }
+        else {
+            $this->costs['forbidden_seal'][3][60] = $this->costs['forbidden_seal_monthly_cost'][3] * 2;
+            $this->costs['forbidden_seal'][3][90] = $this->costs['forbidden_seal_monthly_cost'][3] * 3;
+        }
+    }
+
     private function initCosts(): void {
         $this->costs['name_change'] = 15;
         $this->costs['gender_change'] = 10;
@@ -53,7 +80,8 @@ class PremiumShopManager {
         $this->costs['bloodline_random'][2] = 20;
         $this->costs['forbidden_seal_monthly_cost'] = [
             1 => 5,
-            2 => 15
+            2 => 15,
+            3 => 30,
         ];
         $this->costs['forbidden_seal'] = [
             1 => [
@@ -65,6 +93,11 @@ class PremiumShopManager {
                 30 => $this->costs['forbidden_seal_monthly_cost'][2],
                 60 => $this->costs['forbidden_seal_monthly_cost'][2] * 2,
                 90 => $this->costs['forbidden_seal_monthly_cost'][2] * 3
+            ],
+            3 => [
+                30 => $this->costs['forbidden_seal_monthly_cost'][3],
+                60 => $this->costs['forbidden_seal_monthly_cost'][3] * 2,
+                90 => $this->costs['forbidden_seal_monthly_cost'][3] * 3
             ]
         ];
         $this->costs['element_change'] = 10;

--- a/classes/PremiumShopManager.php
+++ b/classes/PremiumShopManager.php
@@ -17,6 +17,7 @@ class PremiumShopManager {
 
     const TIER_THREE_SALE_END = '2023-11-30';
     const SALE_REFUND_RATE = 50;
+    const EDS_90_DAY_DISCOUNT = 0.17;
 
     public System $system;
     public User $player;
@@ -97,7 +98,7 @@ class PremiumShopManager {
             3 => [
                 30 => $this->costs['forbidden_seal_monthly_cost'][3],
                 60 => $this->costs['forbidden_seal_monthly_cost'][3] * 2,
-                90 => $this->costs['forbidden_seal_monthly_cost'][3] * 3
+                90 => $this->calcSealDiscount($this->costs['forbidden_seal_monthly_cost'][3] * 3, self::EDS_90_DAY_DISCOUNT)
             ]
         ];
         $this->costs['element_change'] = 10;
@@ -112,6 +113,10 @@ class PremiumShopManager {
 
         $this->costs['reset_ai_battles'] = 10;
         $this->costs['reset_pvp_battles'] = 20;
+    }
+
+    private function calcSealDiscount(int $cost, float $discount_rate): int {
+        return $cost - floor($cost * $discount_rate);
     }
 
     private function initStatTransferVars(): void {

--- a/pages/premium_shop.php
+++ b/pages/premium_shop.php
@@ -13,6 +13,11 @@ function premiumShop(): void {
 
     $premiumShopManager = new PremiumShopManager($system, $player);
 
+    //TEMPORARY SALE LOGIC
+    if($premiumShopManager->tierThreeSaleActive()) {
+        $premiumShopManager->loadTierThreeSalePrices($player->forbidden_seal->level);
+    }
+
     $available_clans = $premiumShopManager->getAvailableClans();
     $available_name_colors = $player->getNameColors();
 
@@ -461,6 +466,9 @@ function premiumShop(): void {
                     // Convert remaining premium time to days and calculate AK value
                     $akCredit = $player->forbidden_seal->calcRemainingCredit();
 
+                    // TEMPORARY SALE LOGIC
+                    $remainingCredit = max(0, $akCredit - $ak_cost);
+
                     // Adjust purchase cost with minimum 0
                     $ak_cost -= $akCredit;
                     if ($ak_cost < 0) {
@@ -471,6 +479,15 @@ function premiumShop(): void {
                     You will lose {$system->time_remaining($player->forbidden_seal->seal_time_remaining)} of premium time.<br />
                     Up to {$akCredit} Ancient Kunai will be credited toward your purchase from existing premium time.<br />
                     <b>This can not be undone!</b>";
+
+                    // TEMPORARY SALE LOGIC
+                    if($premiumShopManager->tierThreeSaleActive() && ($player->forbidden_seal->level == 1 || $player->forbidden_seal->level == 2) && $seal_level == 3) {
+                        if($remainingCredit > 1) {
+                            $confirmation_string .= "<br /><br />
+                            <b>" . ForbiddenSeal::$forbidden_seal_names[3] . " Sale!</b><br />
+                            You will also receive an estimated refund of " . floor($remainingCredit * (PremiumShopManager::SALE_REFUND_RATE/100)) . " AK.";
+                        }
+                    }
 
                     renderPurchaseConfirmation(
                         purchase_type: 'forbidden_seal',
@@ -485,14 +502,22 @@ function premiumShop(): void {
                         ak_cost: $ak_cost
                     );
                 } else {
-                    $message = "Purchased " . ForbiddenSeal::$forbidden_seal_names[$seal_level] . " seal for {$seal_length} days.";
-                    if ($overwrite) {
-                        $message .= " This purchase removed {$system->time_remaining($player->forbidden_seal->seal_time_remaining)}" .
-                            " of their {$player->forbidden_seal->name}.";
-                    }
+                    $message = "Purchased " . ForbiddenSeal::$forbidden_seal_names[$seal_level] . " seal for {$seal_length} days.
+                    This purchase removed {$system->time_remaining($player->forbidden_seal->seal_time_remaining)}
+                        of their {$player->forbidden_seal->name}.";
                     // Recalculate adjusted akCost
                     if ($player->forbidden_seal->level > 0) {
                         $akCredit = $player->forbidden_seal->calcRemainingCredit();
+
+                        //TEMPORARY SALE LOGIC
+                        if($premiumShopManager->tierThreeSaleActive() && $seal_level == 3) {
+                            $remainingCredit = $akCredit - $ak_cost;
+                            if($remainingCredit > 1) {
+                                $refund = floor($remainingCredit * (PremiumShopManager::SALE_REFUND_RATE/100));
+                                $player->addPremiumCredits($refund, "Tier 3 seal sale refund.");
+                            }
+                        }
+
                         $ak_cost -= $akCredit;
                         if ($ak_cost < 0) {
                             $ak_cost = 0;
@@ -501,6 +526,11 @@ function premiumShop(): void {
 
                     $player->subtractPremiumCredits($ak_cost, $message);
                     $player->forbidden_seal->addSeal($seal_level, $seal_length);
+
+                    //TEMPORARY SALE LOGIC - Run for display purposes
+                    if($premiumShopManager->tierThreeSaleActive()) {
+                        $premiumShopManager->loadTierThreeSalePrices($player->forbidden_seal->level);
+                    }
 
                     $system->message("You changed your seal!");
                 }
@@ -518,6 +548,11 @@ function premiumShop(): void {
                 //Load benefits for displaying market & storing in db
                 $player->forbidden_seal->setBenefits();
                 $player->forbidden_seal_loaded = true;
+
+                //TEMPORARY SALE LOGIC - Run for display purposes
+                if($premiumShopManager->tierThreeSaleActive()) {
+                    $premiumShopManager->loadTierThreeSalePrices($player->forbidden_seal->level);
+                }
 
                 $system->message("Seal infused!");
             }
@@ -851,6 +886,8 @@ function premiumShop(): void {
     $twinSeal->setBenefits();
     $fourDragonSeal = new ForbiddenSeal($system, 2);
     $fourDragonSeal->setBenefits();
+    $eightTrigramSeal = new ForbiddenSeal($system, 3);
+    $eightTrigramSeal->setBenefits();
 
     require "templates/premium/premium.php";
 }

--- a/pages/premium_shop.php
+++ b/pages/premium_shop.php
@@ -13,11 +13,6 @@ function premiumShop(): void {
 
     $premiumShopManager = new PremiumShopManager($system, $player);
 
-    //TEMPORARY SALE LOGIC
-    if($premiumShopManager->tierThreeSaleActive()) {
-        $premiumShopManager->loadTierThreeSalePrices($player->forbidden_seal->level);
-    }
-
     $available_clans = $premiumShopManager->getAvailableClans();
     $available_name_colors = $player->getNameColors();
 
@@ -527,11 +522,6 @@ function premiumShop(): void {
                     $player->subtractPremiumCredits($ak_cost, $message);
                     $player->forbidden_seal->addSeal($seal_level, $seal_length);
 
-                    //TEMPORARY SALE LOGIC - Run for display purposes
-                    if($premiumShopManager->tierThreeSaleActive()) {
-                        $premiumShopManager->loadTierThreeSalePrices($player->forbidden_seal->level);
-                    }
-
                     $system->message("You changed your seal!");
                 }
             }
@@ -548,11 +538,6 @@ function premiumShop(): void {
                 //Load benefits for displaying market & storing in db
                 $player->forbidden_seal->setBenefits();
                 $player->forbidden_seal_loaded = true;
-
-                //TEMPORARY SALE LOGIC - Run for display purposes
-                if($premiumShopManager->tierThreeSaleActive()) {
-                    $premiumShopManager->loadTierThreeSalePrices($player->forbidden_seal->level);
-                }
 
                 $system->message("Seal infused!");
             }

--- a/templates/premium/premium.php
+++ b/templates/premium/premium.php
@@ -5,6 +5,7 @@
  * @var PremiumShopManager $premiumShopManager
  * @var ForbiddenSeal $twinSeal
  * @var ForbiddenSeal $fourDragonSeal
+ * @var ForbiddenSeal $eightTrigramSeal
  * @var string $self_link
  * @var string $view
  * @var array  $available_clans
@@ -212,6 +213,51 @@
                             <?php endforeach ?>
                         </select><br/>
                         <input type='submit' style='margin-top: 5px' name='forbidden_seal' value='<?= ($player->forbidden_seal->level == 2 ? 'Extend' : 'Purchase') ?>' />
+                    </p>
+                </form>
+            </td>
+        </tr>
+        <tr>
+            <th id='premium_eightTrigramSeal_header' colspan="2"><?=$eightTrigramSeal->name?></th>
+        </tr>
+        <tr>
+            <td colspan="2" style="text-align: center;">
+                <p style='font-weight:bold;text-align:center;'>
+                    <?= $premiumShopManager->costs['forbidden_seal_monthly_cost'][3] ?> Ancient Kunai / 30 days</p>
+                <br/>
+                All benefits of <?=$fourDragonSeal->name?><br />
+                Longer journal (<?=$eightTrigramSeal->journal_size?> characters)<br />
+                Journal image size of <?=$eightTrigramSeal->journal_image_display?><br />
+                Enhanced long trainings (<?=$eightTrigramSeal->long_training_time?>x length, <?=$eightTrigramSeal->long_training_gains?>x gains)<br />
+                Enhanced extended trainings (<?=$eightTrigramSeal->extended_training_time?>x length, <?=$eightTrigramSeal->extended_training_gains?>x gains)<br />
+                Faster stat transfers(+<?=$eightTrigramSeal->stat_transfer_boost?>/minute)<br />
+                View logs of your last <?=$eightTrigramSeal->max_battle_history_view?> battles
+
+                <!--TEMPORARY SALE LOGIC-->
+                <?php if($premiumShopManager->tierThreeSaleActive()): ?>
+                    <br /><br />
+                    <b><?=$eightTrigramSeal->name?> SALE!</b>
+                    <p style='margin: 0;' id="sale_time_remaining"><?= System::timeRemaining($premiumShopManager->saleTimeRemaining(), 'short') ?> Remaining</p>
+                    <script type="text/javascript">
+                        countdownTimer(<?=$premiumShopManager->saleTimeRemaining()?>, 'sale_time_remaining');
+                    </script>
+                    <br />
+                    <?php if($player->forbidden_seal->level == 0 || $player->forbidden_seal->level == 3): ?>
+                        Sixty (60) and ninety (90) day seal purchases are currently discounted!
+                    <?php else: ?>
+                        Any estimated seal credit above purchase price will be refunded at <?=PremiumShopManager::SALE_REFUND_RATE?>%
+                    <?php endif ?>
+                <?php endif ?>
+
+                <form action='<?= $self_link ?>&view=forbidden_seal' method='post'>
+                    <p style='width:100%;text-align:center;margin: 2.2em 0 0;'>
+                        <input type='hidden' name='seal_level' value='3'/>
+                        <select name='seal_length'>
+                            <?php foreach($premiumShopManager->costs['forbidden_seal'][3] as $pLength => $pCost): ?>
+                                <option value="<?=$pLength?>"><?=$pLength?> days (<?=$pCost?> AK)</option>
+                            <?php endforeach ?>
+                        </select><br/>
+                        <input type='submit' style='margin-top: 5px' name='forbidden_seal' value='<?= ($player->forbidden_seal->level == 3 ? 'Extend' : 'Purchase') ?>' />
                     </p>
                 </form>
             </td>

--- a/templates/premium/premium.php
+++ b/templates/premium/premium.php
@@ -242,9 +242,7 @@
                         countdownTimer(<?=$premiumShopManager->saleTimeRemaining()?>, 'sale_time_remaining');
                     </script>
                     <br />
-                    <?php if($player->forbidden_seal->level == 0 || $player->forbidden_seal->level == 3): ?>
-                        Sixty (60) and ninety (90) day seal purchases are currently discounted!
-                    <?php else: ?>
+                    <?php if($player->forbidden_seal->level == 1 || $player->forbidden_seal->level == 2): ?>
                         Any estimated seal credit above purchase price will be refunded at <?=PremiumShopManager::SALE_REFUND_RATE?>%
                     <?php endif ?>
                 <?php endif ?>

--- a/templates/premium/premium.php
+++ b/templates/premium/premium.php
@@ -235,14 +235,14 @@
 
                 <!--TEMPORARY SALE LOGIC-->
                 <?php if($premiumShopManager->tierThreeSaleActive()): ?>
-                    <br /><br />
-                    <b><?=$eightTrigramSeal->name?> SALE!</b>
-                    <p style='margin: 0;' id="sale_time_remaining"><?= System::timeRemaining($premiumShopManager->saleTimeRemaining(), 'short') ?> Remaining</p>
-                    <script type="text/javascript">
-                        countdownTimer(<?=$premiumShopManager->saleTimeRemaining()?>, 'sale_time_remaining');
-                    </script>
-                    <br />
                     <?php if($player->forbidden_seal->level == 1 || $player->forbidden_seal->level == 2): ?>
+                        <br /><br />
+                        <b><?=$eightTrigramSeal->name?> SALE!</b>
+                        <p style='margin: 0;' id="sale_time_remaining"><?= System::timeRemaining($premiumShopManager->saleTimeRemaining(), 'short') ?> Remaining</p>
+                        <script type="text/javascript">
+                            countdownTimer(<?=$premiumShopManager->saleTimeRemaining()?>, 'sale_time_remaining');
+                        </script>
+                        <br />
                         Any estimated seal credit above purchase price will be refunded at <?=PremiumShopManager::SALE_REFUND_RATE?>%
                     <?php endif ?>
                 <?php endif ?>

--- a/templates/premium/premium.php
+++ b/templates/premium/premium.php
@@ -226,6 +226,7 @@
                     <?= $premiumShopManager->costs['forbidden_seal_monthly_cost'][3] ?> Ancient Kunai / 30 days</p>
                 <br/>
                 All benefits of <?=$fourDragonSeal->name?><br />
+                +<?=$eightTrigramSeal->regen_boost?>% regen rate<br/>
                 Longer journal (<?=$eightTrigramSeal->journal_size?> characters)<br />
                 Journal image size of <?=$eightTrigramSeal->journal_image_display?><br />
                 Enhanced long trainings (<?=$eightTrigramSeal->long_training_time?>x length, <?=$eightTrigramSeal->long_training_gains?>x gains)<br />


### PR DESCRIPTION
Added Eight Trigram seal

Benefits:
+25% Regeneration rate
Longer journal (3500 characters)
Journal image size of 600x600
Enhanced long trainings (1.5x length, 2.2x gains)
Enhanced extended trainings (2x length, 3x gains)
Faster stat transfers(+6/minute)
View logs of your last 50 battles

Comparison to T2 seal
+5% Regeneration rate
+1000 journal characters
+100x100 journal image size
Long trainings +20% gains
Extended trainings +25% length, +50% gains
+1 stat/minute transfer
+30 battle log history

Update comes with a seal sale, ends Nov 30:
Upgrading to T3 seal from T1 or T2 will provide a 50% refund, if any credit exists over the purchase price. Estimated refunds will be displayed in the purchase confirmation screen.