### PR TITLE
War Tweaks

### DIFF
--- a/classes/notification/Notifications.php
+++ b/classes/notification/Notifications.php
@@ -47,9 +47,12 @@ class Notifications {
                     case Battle::TYPE_FIGHT:
                         $link = $system->router->links['battle'];
                         break;
-                    /* case Battle::TYPE_CHALLENGE:
-                         $link = $system->router->links['spar'];
-                         break;*/
+                    case Battle::TYPE_CHALLENGE:
+                        $link = $system->router->links['challenge'];
+                        break;
+                    case Battle::TYPE_AI_WAR:
+                        $link = $system->router->links['war'];
+                        break;
                 }
                 if($link) {
                     $notifications[] = new Notification($link, "In battle!", critical: true);

--- a/classes/travel/TravelManager.php
+++ b/classes/travel/TravelManager.php
@@ -586,10 +586,12 @@ class TravelManager {
             throw new RuntimeException("You died within the last minute, please wait " .
                 ceil((($this->user->last_death_ms + (60 * 1000)) - System::currentTimeMs()) / 1000) . " more seconds.");
         }
+        // we already give PvP immunity that breaks on attacking/war so this old restriction isn't needed
+        /*
         if ($user->last_death_ms > System::currentTimeMs() - (60 * 1000)) {
             throw new RuntimeException("Target has died within the last minute, please wait " .
                 ceil((($user->last_death_ms + (60 * 1000)) - System::currentTimeMs()) / 1000) . " more seconds.");
-        }
+        }*/
         if ($this->user->operation > 0) {
             throw new RuntimeException("You are currently in an operation!");
         }

--- a/classes/village/VillagePolicy.php
+++ b/classes/village/VillagePolicy.php
@@ -101,7 +101,7 @@ class VillagePolicy {
                 self::POLICY_BONUS_PATROL_TIER => 0,
                 self::POLICY_BONUS_TRAINING_SPEED => 5,
                 self::POLICY_BONUS_FREE_TRANSFER => true,
-                self::POLICY_BONUS_HOME_PRODUCTION_BOOST => 100,
+                self::POLICY_BONUS_HOME_PRODUCTION_BOOST => 50,
                 self::POLICY_BONUS_SCOUTING => 0,
                 self::POLICY_BONUS_STEALTH => 0,
                 self::POLICY_BONUS_LOOT_CAPACITY => 0,

--- a/classes/village/VillagePolicy.php
+++ b/classes/village/VillagePolicy.php
@@ -101,7 +101,7 @@ class VillagePolicy {
                 self::POLICY_BONUS_PATROL_TIER => 0,
                 self::POLICY_BONUS_TRAINING_SPEED => 5,
                 self::POLICY_BONUS_FREE_TRANSFER => true,
-                self::POLICY_BONUS_HOME_PRODUCTION_BOOST => 50,
+                self::POLICY_BONUS_HOME_PRODUCTION_BOOST => 100,
                 self::POLICY_BONUS_SCOUTING => 0,
                 self::POLICY_BONUS_STEALTH => 0,
                 self::POLICY_BONUS_LOOT_CAPACITY => 0,

--- a/classes/war/Operation.php
+++ b/classes/war/Operation.php
@@ -335,8 +335,9 @@ class Operation {
                     $patrol_spawn = time() + (60 * 5);
                     $this->system->db->query("UPDATE `patrols` SET `start_time` = {$patrol_spawn}, `village_id` = {$this->user->village->village_id} WHERE `region_id` = {$location_target['region_id']}");
                     // update caravans, change only caravans that haven't spawned
+                    $name = VillageManager::VILLAGE_NAMES[$this->user->village->village_id] . " Caravan";
                     $time = time();
-                    $this->system->db->query("UPDATE `caravans` SET `village_id` = {$this->user->village->village_id} WHERE `region_id` = {$location_target['region_id']} AND `start_time` > {$time}");
+                    $this->system->db->query("UPDATE `caravans` SET `village_id` = {$this->user->village->village_id}, `name` = {$name} WHERE `region_id` = {$location_target['region_id']} AND `start_time` > {$time}");
                 }
                 else if ($location_target['defense'] > 0) {
                     $result = max($location_target['defense'] - $defense_reduction, 0);

--- a/classes/war/WarManager.php
+++ b/classes/war/WarManager.php
@@ -2,6 +2,7 @@
 
 class WarManager {
     const BASE_RESOURCE_PRODUCTION = 25; // 25/hour, 600/village/day, 1800/region/day, 7200/faction/day (assuming 4 regions)
+    const HOME_REGION_RESOURCE_BONUS = 25;
     const BASE_CARAVAN_TIME_MS = 300000; // 5 minute travel time
     const CARAVAN_TIMER_HOURS = 6; // 24m average caravan spawn timer, so 19 minute average downtime
     const BASE_VILLAGE_REGEN = 1250;

--- a/cron_jobs/region_cron.php
+++ b/cron_jobs/region_cron.php
@@ -109,7 +109,7 @@ function hourlyRegion(System $system, $debug = true): void
             // if one of the home regions, collect resources bypassing caravans
             $production = WarManager::BASE_RESOURCE_PRODUCTION;
             if ($region['region_id'] <= 5) {
-                $production += WarManager::HOME_REGION_RESOURCE_BONUS;
+                //$production += WarManager::HOME_REGION_RESOURCE_BONUS;
                 $production += floor(WarManager::BASE_RESOURCE_PRODUCTION * ($villages[$region['village']]->policy->home_production_boost / 100));
                 $villages[$region['village']]->addResource($region_location['resource_id'], $region_location['resource_count']);
                 $queries[] = "INSERT INTO `resource_logs`

--- a/cron_jobs/region_cron.php
+++ b/cron_jobs/region_cron.php
@@ -109,6 +109,7 @@ function hourlyRegion(System $system, $debug = true): void
             // if one of the home regions, collect resources bypassing caravans
             $production = WarManager::BASE_RESOURCE_PRODUCTION;
             if ($region['region_id'] <= 5) {
+                $production += WarManager::HOME_REGION_RESOURCE_BONUS;
                 $production += floor(WarManager::BASE_RESOURCE_PRODUCTION * ($villages[$region['village']]->policy->home_production_boost / 100));
                 $villages[$region['village']]->addResource($region_location['resource_id'], $region_location['resource_count']);
                 $queries[] = "INSERT INTO `resource_logs`

--- a/ui_components/build/village/Village.js
+++ b/ui_components/build/village/Village.js
@@ -83,7 +83,7 @@ function Village({
         data.name = "From the Ashes";
         data.phrase = "bonds forged, courage shared.";
         data.description = "In unity, find the strength to overcome.\nOne village, one heart, one fight.";
-        data.bonuses = ["25% increased Caravan speed", "+100% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
+        data.bonuses = ["25% increased Caravan speed", "+50% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
         data.penalties = ["-25 Materials/hour", "-35 Food/hour", "-15 Wealth/hour", "Cannot declare War"];
         data.glowClass = "growth_glow";
         break;

--- a/ui_components/build/village/Village.js
+++ b/ui_components/build/village/Village.js
@@ -83,7 +83,7 @@ function Village({
         data.name = "From the Ashes";
         data.phrase = "bonds forged, courage shared.";
         data.description = "In unity, find the strength to overcome.\nOne village, one heart, one fight.";
-        data.bonuses = ["25% increased Caravan speed", "+100% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
+        data.bonuses = ["25% increased Caravan speed", "+50% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
         data.penalties = ["-25 Materials/hour", "-35 Food/hour", "-15 Wealth/hour", "Cannot declare War"];
         data.glowClass = "growth_glow";
         break;
@@ -92,7 +92,7 @@ function Village({
         data.name = "Eye of the Storm";
         data.phrase = "half truths, all lies.";
         data.description = "Become informants dealing in truths and lies.\nDeceive, divide and destroy.";
-        data.bonuses = ["25% increased Infiltrate speed", "+1 Defense reduction from Infiltrate", "+1 Stealth", "+15 Loot Capacity"];
+        data.bonuses = ["25% increased Infiltrate speed", "+1 Defense reduction from Infiltrate", "+1 Stealth", "+5 Loot Capacity"];
         data.penalties = ["-15 Materials/hour", "-15 Food/hour", "-45 Wealth/hour"];
         data.glowClass = "espionage_glow";
         break;

--- a/ui_components/build/village/Village.js
+++ b/ui_components/build/village/Village.js
@@ -83,7 +83,7 @@ function Village({
         data.name = "From the Ashes";
         data.phrase = "bonds forged, courage shared.";
         data.description = "In unity, find the strength to overcome.\nOne village, one heart, one fight.";
-        data.bonuses = ["25% increased Caravan speed", "+50% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
+        data.bonuses = ["25% increased Caravan speed", "+100% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
         data.penalties = ["-25 Materials/hour", "-35 Food/hour", "-15 Wealth/hour", "Cannot declare War"];
         data.glowClass = "growth_glow";
         break;

--- a/ui_components/src/village/Village.js
+++ b/ui_components/src/village/Village.js
@@ -81,7 +81,7 @@ function Village({
                 data.name = "From the Ashes";
                 data.phrase = "bonds forged, courage shared.";
                 data.description = "In unity, find the strength to overcome.\nOne village, one heart, one fight.";
-                data.bonuses = ["25% increased Caravan speed", "+100% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
+                data.bonuses = ["25% increased Caravan speed", "+50% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
                 data.penalties = ["-25 Materials/hour", "-35 Food/hour", "-15 Wealth/hour", "Cannot declare War"];
                 data.glowClass = "growth_glow";
                 break;
@@ -90,7 +90,7 @@ function Village({
                 data.name = "Eye of the Storm";
                 data.phrase = "half truths, all lies.";
                 data.description = "Become informants dealing in truths and lies.\nDeceive, divide and destroy.";
-                data.bonuses = ["25% increased Infiltrate speed", "+1 Defense reduction from Infiltrate", "+1 Stealth", "+15 Loot Capacity"];
+                data.bonuses = ["25% increased Infiltrate speed", "+1 Defense reduction from Infiltrate", "+1 Stealth", "+5 Loot Capacity"];
                 data.penalties = ["-15 Materials/hour", "-15 Food/hour", "-45 Wealth/hour"];
                 data.glowClass = "espionage_glow";
                 break;

--- a/ui_components/src/village/Village.js
+++ b/ui_components/src/village/Village.js
@@ -81,7 +81,7 @@ function Village({
                 data.name = "From the Ashes";
                 data.phrase = "bonds forged, courage shared.";
                 data.description = "In unity, find the strength to overcome.\nOne village, one heart, one fight.";
-                data.bonuses = ["25% increased Caravan speed", "+100% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
+                data.bonuses = ["25% increased Caravan speed", "+50% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
                 data.penalties = ["-25 Materials/hour", "-35 Food/hour", "-15 Wealth/hour", "Cannot declare War"];
                 data.glowClass = "growth_glow";
                 break;

--- a/ui_components/src/village/Village.js
+++ b/ui_components/src/village/Village.js
@@ -81,7 +81,7 @@ function Village({
                 data.name = "From the Ashes";
                 data.phrase = "bonds forged, courage shared.";
                 data.description = "In unity, find the strength to overcome.\nOne village, one heart, one fight.";
-                data.bonuses = ["25% increased Caravan speed", "+50% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
+                data.bonuses = ["25% increased Caravan speed", "+100% resource production [home region]", "+5% training speed", "Free incoming village transfer"];
                 data.penalties = ["-25 Materials/hour", "-35 Food/hour", "-15 Wealth/hour", "Cannot declare War"];
                 data.glowClass = "growth_glow";
                 break;


### PR DESCRIPTION
- Removed 60s immunity from being attacked after a loss
We already have the 5-min immunity so this is doubling up, and it causes issues in war when someone does war actions during the immunity.
- Added battle links for old layouts
- Fixed caravan name on region change