### PR TITLE
War XP Rebalance

### DIFF
--- a/classes/UserReputation.php
+++ b/classes/UserReputation.php
@@ -125,8 +125,8 @@ class UserReputation {
         Operation::OPERATION_REINFORCE => 3,
         Operation::OPERATION_INFILTRATE => 4,
         Operation::OPERATION_RAID => 5,
-        Operation::OPERATION_LOOT => 1,
-        Operation::OPERATION_LOOT_TOWN => 1,
+        Operation::OPERATION_LOOT => 0,
+        Operation::OPERATION_LOOT_TOWN => 0,
     ];
 
     const DAILY_TASK_REWARDS = [

--- a/classes/war/Operation.php
+++ b/classes/war/Operation.php
@@ -34,9 +34,9 @@ class Operation {
     ];
 
     const OPERATION_STAT_GAIN = [
-        self::OPERATION_INFILTRATE => 2,
-        self::OPERATION_REINFORCE => 1,
-        self::OPERATION_RAID => 2,
+        self::OPERATION_INFILTRATE => 3,
+        self::OPERATION_REINFORCE => 2,
+        self::OPERATION_RAID => 4,
         self::OPERATION_LOOT => 0,
         self::OPERATION_LOOT_TOWN => 0,
     ];

--- a/classes/war/WarManager.php
+++ b/classes/war/WarManager.php
@@ -56,6 +56,7 @@ class WarManager {
     const MAX_PATROL_TIER = 3;
     const YEN_PER_RESOURCE = 20;
     const RESOURCES_PER_STAT = 10;
+    const RESOURCES_PER_REPUTATION = 10;
 
     private System $system;
     private User $user;
@@ -412,6 +413,7 @@ class WarManager {
         }
         $yen_gain = $total_resources * self::YEN_PER_RESOURCE;
         $stat_gain = floor($total_resources / self::RESOURCES_PER_STAT);
+        $rep_gain = floor($total_resources / self::RESOURCES_PER_REPUTATION);
         $this->user->village->updateResources();
         $message .= "!";
         // add yen
@@ -423,6 +425,16 @@ class WarManager {
             $stat_gained = $this->user->addStatGain($stat_to_gain, $stat_gain);
             if (!empty($stat_gained)) {
                 $message .= "\n" . $stat_gained;
+            }
+        }
+        // Add reputation
+        if ($this->user->reputation->canGain(UserReputation::ACTIVITY_TYPE_WAR)) {
+            $rep_gain = $this->user->reputation->addRep(
+                amount: $rep_gain,
+                activity_type: UserReputation::ACTIVITY_TYPE_WAR
+            );
+            if ($rep_gain > 0) {
+                $message .= "\nGained " . $rep_gain . " village reputation!";
             }
         }
         $message .= '!';


### PR DESCRIPTION
Loot/Reinforce/Infiltrate/Raid
Chuu: 0/2/3/4 
Jonin: 0/3/4/5

Resource Gains
Loot / 10 = Stat Gain
Loot / 10 = Rep Gain
e.g. 1 stat per loot action, 1 bonus stat per 2 Infiltrates

======================

Reinforce/Hour
Lv50 Chuunin: 46/hour
lv100 Jonin: 75/hour

Infiltrate/Hour (w/ loot)
lv50 Chuunin: 80/hour
lv100 Jonin: 112.5/hour

Raid/Hour
lv50 Chuunin: 92/hour
lv100 Jonin: 125/hour

Short/Hour
Chuunin, no bonus: 96/hour
Chuunin, clan + team: 113/hour (9min with 6% increased gains)
Jonin, no bonus: 120/hour
Jonin, clan + team: 141/hour (9min with 6% increased gains)

Special Mission (Normal)/Hour 
Chuunin: 102/hour (3.5min for 6 stats)
Jonin: 137/hour (3.5min for 8 stats)

Special Mission (Nightmare)/Hour
Chuunin: 133/hour (4.5min for 10 stats)
Jonin: 160/hour (4.5min for 12 stats)
