### PR TITLE
Evasion Rework / Bloodline Bonuses

### DIFF
--- a/admin/constraints/bloodline.php
+++ b/admin/constraints/bloodline.php
@@ -14,6 +14,7 @@ $bloodline_combat_boosts = [
     'intelligence_boost',
     'willpower_boost',
     'heal',
+    'damage_resist',
 ];
 $passive_boosts = [
     'scout_range',

--- a/admin/constraints/jutsu.php
+++ b/admin/constraints/jutsu.php
@@ -22,6 +22,8 @@ $jutsu_effects = [
     'endurance_nerf',
     'intelligence_nerf',
     'willpower_nerf',
+    'evasion_boost',
+    'evasion_nerf',
 ];
 
 $ranks = [];

--- a/admin/entity_constraints.php
+++ b/admin/entity_constraints.php
@@ -235,7 +235,7 @@ $constraints['ai'] = [
             'effect' => [
                 'data_type' => 'string',
                 'input_type' => 'text',
-                'options' => ['none', 'residual_damage', 'taijutsu_boost', 'ninjutsu_boost', 'genjutsu_boost', 'speed_boost', 'cast_speed_boost', 'speed_nerf'],
+                'options' => ['none', 'residual_damage', 'taijutsu_boost', 'ninjutsu_boost', 'genjutsu_boost', 'speed_boost', 'cast_speed_boost', 'speed_nerf', 'evasion_boost', 'evasion_nerf'],
             ],
             'effect_amount' => [
                 'data_type' => 'string',

--- a/classes/Bloodline.php
+++ b/classes/Bloodline.php
@@ -15,6 +15,8 @@ class Bloodline {
 
     const BOOST_POWER_PRECISION = 5;
 
+    const HEAL_RANGE_PERCENT = 25;
+
     public static array $public_ranks = [
         self::RANK_LEGENDARY => 'Legendary',
         self::RANK_ELITE  => 'Elite',
@@ -154,13 +156,13 @@ class Bloodline {
     ): void {
         $ratios = [
             'offense_boost' => 0.02,
-            'defense_boost' => 0.045,
+            'defense_boost' => 0.03,
             'speed_boost' => 0.08,
             'mental_boost' => 0.1,
-            'heal' => 0.036,
+            'heal' => 0.03,
             'regen' => 0.15,
         ];
-        $bloodline_skill += self::BASE_BLOODLINE_SKILL;
+        $bloodline_skill += $bloodline_skill < 100 ? self::BASE_BLOODLINE_SKILL : 0;
 
         if($this->raw_passive_boosts) {
             $this->passive_boosts = json_decode($this->raw_passive_boosts, true);
@@ -233,6 +235,7 @@ class Bloodline {
                 case 'ninjutsu_resist':
                 case 'genjutsu_resist':
                 case 'taijutsu_resist':
+                case 'damage_resist':
                     $this->combat_boosts[$id]['power'] =
                         round($boost_power * $ratios['defense_boost'], Bloodline::BOOST_POWER_PRECISION);
                     break;
@@ -268,9 +271,6 @@ class Bloodline {
 
         $ratio_max = 1.0;
         $ratio_min = 0.75;
-
-        // Adjust to use invested skill only
-        $bloodline_skill -= self::BASE_BLOODLINE_SKILL;
 
         // Handle case with no skill investment
         if ($bloodline_skill <= 0) {

--- a/classes/Bloodline.php
+++ b/classes/Bloodline.php
@@ -15,6 +15,7 @@ class Bloodline {
 
     const BOOST_POWER_PRECISION = 5;
 
+    // 75% effectiveness at 100% HP, 125% effectiveness at 0% HP
     const HEAL_RANGE_PERCENT = 25;
 
     public static array $public_ranks = [

--- a/classes/Bloodline.php
+++ b/classes/Bloodline.php
@@ -15,9 +15,6 @@ class Bloodline {
 
     const BOOST_POWER_PRECISION = 5;
 
-    // 75% effectiveness at 100% HP, 125% effectiveness at 0% HP
-    const HEAL_RANGE_PERCENT = 25;
-
     public static array $public_ranks = [
         self::RANK_LEGENDARY => 'Legendary',
         self::RANK_ELITE  => 'Elite',
@@ -157,7 +154,7 @@ class Bloodline {
     ): void {
         $ratios = [
             'offense_boost' => 0.02,
-            'defense_boost' => 0.03,
+            'defense_boost' => 0.09,
             'speed_boost' => 0.08,
             'mental_boost' => 0.1,
             'heal' => 0.03,

--- a/classes/battle/Battle.php
+++ b/classes/battle/Battle.php
@@ -306,7 +306,6 @@ class Battle {
                     continue;
                 }
                 $this->player1->defense_boost += $boost['effect_amount'] / $this->player2->getBaseStatTotal();
-                echo $this->player1->defense_boost;
             }
         }
         if (!empty($this->player2->bloodline_defense_boosts)) {

--- a/classes/battle/Battle.php
+++ b/classes/battle/Battle.php
@@ -305,7 +305,7 @@ class Battle {
                 if ($boost_type != 'damage') {
                     continue;
                 }
-                $this->player1->defense_boost += $boost['effect_amount'] / $this->player2->getBaseStatTotal();
+                $this->player1->resist_boost += $boost['effect_amount'] / $this->player2->getBaseStatTotal();
             }
         }
         if (!empty($this->player2->bloodline_defense_boosts)) {
@@ -314,7 +314,7 @@ class Battle {
                 if ($boost_type != 'damage') {
                     continue;
                 }
-                $this->player2->defense_boost += $boost['effect_amount'] / $this->player1->getBaseStatTotal();
+                $this->player2->resist_boost += $boost['effect_amount'] / $this->player1->getBaseStatTotal();
             }
         }
     }

--- a/classes/battle/Battle.php
+++ b/classes/battle/Battle.php
@@ -297,6 +297,27 @@ class Battle {
 
         $this->player1->applyBloodlineBoosts();
         $this->player2->applyBloodlineBoosts();
+
+        // Setup bloodline defense bonus
+        if (!empty($this->player1->bloodline_defense_boosts)) {
+            foreach ($this->player1->bloodline_defense_boosts as $id => $boost) {
+                $boost_type = explode('_', $boost['effect'])[0];
+                if ($boost_type != 'damage') {
+                    continue;
+                }
+                $this->player1->defense_boost += $boost['effect_amount'] / $this->player2->getBaseStatTotal();
+                echo $this->player1->defense_boost;
+            }
+        }
+        if (!empty($this->player2->bloodline_defense_boosts)) {
+            foreach ($this->player2->bloodline_defense_boosts as $id => $boost) {
+                $boost_type = explode('_', $boost['effect'])[0];
+                if ($boost_type != 'damage') {
+                    continue;
+                }
+                $this->player2->defense_boost += $boost['effect_amount'] / $this->player1->getBaseStatTotal();
+            }
+        }
     }
 
     /**

--- a/classes/battle/BattleEffect.php
+++ b/classes/battle/BattleEffect.php
@@ -4,7 +4,7 @@ class BattleEffect {
     public static array $buff_effects = [
         'heal','ninjutsu_boost','taijutsu_boost','genjutsu_boost',
         'cast_speed_boost','speed_boost','lighten','intelligence_boost','willpower_boost',
-        'ninjutsu_resist','genjutsu_resist','taijutsu_resist','harden'
+        'ninjutsu_resist','genjutsu_resist','taijutsu_resist','harden','evasion_boost'
     ];
 
     // combat id

--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -379,11 +379,7 @@ class BattleEffectsManager {
             }
         }
         else if($effect->effect == 'heal') {
-            $currentHealthPercent = $target->health / $target->max_health;
-            // At 100% health, 75% effectiveness (-25%)
-            // At 0% health, 125% effectiveness (+25%)
-            $scalingFactor = 1 - (Bloodline::HEAL_RANGE_PERCENT / 100) + (2 * (Bloodline::HEAL_RANGE_PERCENT / 100) * (1 - $currentHealthPercent));
-            $heal = $effect->effect_amount * $scalingFactor;
+            $heal = $effect->effect_amount;
 
             $this->addDisplay($target, $target->getName() . " heals " . "<span class=\"battle_text_heal\" style=\"color:green\">" . round($heal) . "</span>" . " health");
 

--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -76,6 +76,8 @@ class BattleEffectsManager {
             case 'cast_speed_boost':
             case 'speed_nerf':
             case 'cripple':
+            case 'evasion_boost':
+            case 'evasion_nerf':
                 // No changes needed to base number, calculated in applyPassiveEffects
                 break;
             case 'intelligence_boost':
@@ -204,8 +206,11 @@ class BattleEffectsManager {
         else if($effect->effect == 'cast_speed_boost') {
             $target->cast_speed_boost += $target->getCastSpeed(true) * ($effect->effect_amount / 100);
         }
-        else if($effect->effect == 'speed_boost' or $effect->effect == 'lighten') {
+        else if($effect->effect == 'speed_boost') {
             $target->speed_boost += $target->getSpeed(true) * ($effect->effect_amount / 100);
+        }
+        else if($effect->effect == 'evasion_boost' or $effect->effect == 'lighten') {
+            $target->evasion_boost += ($effect->effect_amount / 100);
         }
         else if($effect->effect == 'intelligence_boost') {
             $target->intelligence_boost += $effect->effect_amount;
@@ -226,11 +231,12 @@ class BattleEffectsManager {
             $target->barrier += $effect->effect_amount;
         }
 
-        // Debuffs
-        $effect_amount = $effect->effect_amount - $target->getDebuffResist();
+        // Debuffs - Temp disable, will need reworked later and only impacts NPCs
+        /*$effect_amount = $effect->effect_amount - $target->getDebuffResist();
         if($effect_amount < $effect->effect_amount * Battle::MIN_DEBUFF_RATIO) {
             $effect_amount = $effect->effect_amount * Battle::MIN_DEBUFF_RATIO;
-        }
+        }*/
+        $effect_amount = $effect->effect_amount;
 
         if($effect->effect == 'ninjutsu_nerf') {
             $target->ninjutsu_nerf += $effect_amount;
@@ -247,6 +253,9 @@ class BattleEffectsManager {
 
             $target->speed_nerf = min($target->speed_nerf, $target->getSpeed(true) * self::MAX_SPEED_REDUCTION);
             $target->cast_speed_nerf = min($target->cast_speed_nerf, $target->getCastSpeed(true) * self::MAX_SPEED_REDUCTION);
+        }
+        else if($effect->effect == 'evasion_nerf' or $effect->effect == 'cripple') {
+            $target->evasion_nerf += ($effect_amount / 100);
         }
         else if($effect->effect == 'intelligence_nerf') {
             $target->intelligence_nerf += $effect_amount;
@@ -497,6 +506,12 @@ class BattleEffectsManager {
                 break;
             case 'cast_speed_boost':
                 $announcement_text = "[player]'s Cast Speed is being increased";
+                break;
+            case 'evasion_boost':
+                $announcement_text = "[player]'s Evasion is being increased";
+                break;
+            case 'evasion_nerf':
+                $announcement_text = "[opponent]'s Evasion is being lowered";
                 break;
             default:
                 break;

--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -379,7 +379,12 @@ class BattleEffectsManager {
             }
         }
         else if($effect->effect == 'heal') {
-            $heal = $effect->effect_amount;
+            $currentHealthPercent = $target->health / $target->max_health;
+            // At 100% health, 75% effectiveness (-25%)
+            // At 0% health, 125% effectiveness (+25%)
+            $scalingFactor = 1 - (Bloodline::HEAL_RANGE_PERCENT / 100) + (2 * (Bloodline::HEAL_RANGE_PERCENT / 100) * (1 - $currentHealthPercent));
+            $heal = $effect->effect_amount * $scalingFactor;
+
             $this->addDisplay($target, $target->getName() . " heals " . "<span class=\"battle_text_heal\" style=\"color:green\">" . round($heal) . "</span>" . " health");
 
             $target->health += $heal;

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -1002,8 +1002,8 @@ class BattleManager {
             }
         }
 
-        $player1_evasion_stat_amount = $this->getEvasionStatAmount($player1, $player1_jutsu, $player2->getBaseStatTotal());
-        $player2_evasion_stat_amount = $this->getEvasionStatAmount($player2, $player2_jutsu, $player1->getBaseStatTotal());
+        $player1_evasion_stat_amount = $this->getEvasionPercent($player1, $player1_jutsu, $player2->getBaseStatTotal());
+        $player2_evasion_stat_amount = $this->getEvasionPercent($player2, $player2_jutsu, $player1->getBaseStatTotal());
 
         if($player1_evasion_stat_amount >= $player2_evasion_stat_amount && $player2_jutsu_is_attack) {
             $damage_reduction = round($player1_evasion_stat_amount - $player2_evasion_stat_amount, 2);
@@ -1060,7 +1060,7 @@ class BattleManager {
     /**
      * @throws RuntimeException
      */
-    private function getEvasionStatAmount(Fighter $fighter, Jutsu $fighter_jutsu, int $target_stat_total): float|int {
+    private function getEvasionPercent(Fighter $fighter, Jutsu $fighter_jutsu, int $target_stat_total): float|int {
         switch($fighter_jutsu->jutsu_type) {
             case Jutsu::TYPE_TAIJUTSU:
                 // get speed stat total

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -11,7 +11,7 @@ require_once __DIR__ . '/LegacyFighterAction.php';
 class BattleManager {
     const SPEED_DAMAGE_REDUCTION_RATIO = 1; // e.g. 10% of your stats in speed = 10% evasion
     const CAST_SPEED_DAMAGE_REDUCTION_RATIO = 1; // e.g. 10% of your stats in speed = 10% evasion
-    const MAX_EVASION_DAMAGE_REDUCTION = 0.5; // allows baseline investment of up to half your stats in speed against a speedless opponent
+    const MAX_EVASION_DAMAGE_REDUCTION = 0.5; // LEGACY
     const EVASION_SOFT_CAP = 0.5; // caps at 50% evasion
     const EVASION_SOFT_CAP_RATIO = 0.5; // evasion beyond soft cap only 50% as effective
     const EVASION_HARD_CAP = 0.75; // caps at 75% evasion

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -12,6 +12,9 @@ class BattleManager {
     const SPEED_DAMAGE_REDUCTION_RATIO = 1; // e.g. 10% of your stats in speed = 10% evasion
     const CAST_SPEED_DAMAGE_REDUCTION_RATIO = 1; // e.g. 10% of your stats in speed = 10% evasion
     const MAX_EVASION_DAMAGE_REDUCTION = 0.5; // allows baseline investment of up to half your stats in speed against a speedless opponent
+    const EVASION_SOFT_CAP = 0.5; // caps at 50% evasion
+    const EVASION_SOFT_CAP_RATIO = 0.5; // evasion beyond soft cap only 50% as effective
+    const EVASION_HARD_CAP = 0.75; // caps at 75% evasion
 
     private System $system;
 
@@ -1005,9 +1008,15 @@ class BattleManager {
         if($player1_evasion_stat_amount >= $player2_evasion_stat_amount && $player2_jutsu_is_attack) {
             $damage_reduction = round($player1_evasion_stat_amount - $player2_evasion_stat_amount, 2);
 
-            if($damage_reduction > self::MAX_EVASION_DAMAGE_REDUCTION) {
-                $damage_reduction = self::MAX_EVASION_DAMAGE_REDUCTION;
+            // if higher than soft cap, apply penalty
+            if ($damage_reduction > self::EVASION_SOFT_CAP) {
+                $damage_reduction = (($damage_reduction - self::EVASION_SOFT_CAP) * self::EVASION_SOFT_CAP_RATIO) + $damage_reduction - self::EVASION_SOFT_CAP;
             }
+            // if still higher than cap cap, set to hard cap
+            if ($damage_reduction > self::EVASION_HARD_CAP) {
+                $damage_reduction = self::EVASION_HARD_CAP;
+            }
+
             if($damage_reduction >= 0.01) {
                 $player2_damage *= 1 - $damage_reduction;
 
@@ -1023,9 +1032,15 @@ class BattleManager {
         else if($player2_evasion_stat_amount >= $player1_evasion_stat_amount && $player1_jutsu_is_attack) {
             $damage_reduction = round($player2_evasion_stat_amount - $player1_evasion_stat_amount, 2);
 
-            if($damage_reduction > self::MAX_EVASION_DAMAGE_REDUCTION) {
-                $damage_reduction = self::MAX_EVASION_DAMAGE_REDUCTION;
+            // if higher than soft cap, apply penalty
+            if ($damage_reduction > self::EVASION_SOFT_CAP) {
+                $damage_reduction = (($damage_reduction - self::EVASION_SOFT_CAP) * self::EVASION_SOFT_CAP_RATIO) + $damage_reduction - self::EVASION_SOFT_CAP;
             }
+            // if still higher than cap cap, set to hard cap
+            if ($damage_reduction > self::EVASION_HARD_CAP) {
+                $damage_reduction = self::EVASION_HARD_CAP;
+            }
+
             if($damage_reduction >= 0.01) {
                 $player1_damage *= 1 - $damage_reduction;
 

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -1049,24 +1049,22 @@ class BattleManager {
         switch($fighter_jutsu->jutsu_type) {
             case Jutsu::TYPE_TAIJUTSU:
                 // get speed stat total
-                $evasion_stat_amount = $fighter->speed;
+                $evasion_stat_amount = $fighter->speed + $fighter->speed_boost;
                 // determine base evasion against opponent
                 $evasion_stat_amount *= BattleManager::SPEED_DAMAGE_REDUCTION_RATIO / max($target_stat_total, 1);
                 // apply all boosts/nerfs to evasion
                 $evasion_stat_amount += $fighter->evasion_boost;
                 $evasion_stat_amount -= $fighter->evasion_nerf;
-                echo ("<br>" . $fighter->evasion_boost . " " . $fighter->evasion_nerf);
                 break;
             case Jutsu::TYPE_GENJUTSU:
             case Jutsu::TYPE_NINJUTSU:
                 // get speed stat total
-                $evasion_stat_amount = $fighter->cast_speed;
+                $evasion_stat_amount = $fighter->cast_speed + $fighter->cast_speed_boost;
                 // determine base evasion against opponent
                 $evasion_stat_amount *= BattleManager::SPEED_DAMAGE_REDUCTION_RATIO / max($target_stat_total, 1);
                 // apply all boosts/nerfs to evasion
                 $evasion_stat_amount += $fighter->evasion_boost;
                 $evasion_stat_amount -= $fighter->evasion_nerf;
-                echo ("<br>" . $fighter->evasion_boost . " " . $fighter->evasion_nerf);
                 break;
             default:
                 throw new RuntimeException("Invalid jutsu type!");

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -1010,7 +1010,7 @@ class BattleManager {
 
             // if higher than soft cap, apply penalty
             if ($damage_reduction > self::EVASION_SOFT_CAP) {
-                $damage_reduction = (($damage_reduction - self::EVASION_SOFT_CAP) * self::EVASION_SOFT_CAP_RATIO) + $damage_reduction - self::EVASION_SOFT_CAP;
+                $damage_reduction = (($damage_reduction - self::EVASION_SOFT_CAP) * self::EVASION_SOFT_CAP_RATIO) + self::EVASION_SOFT_CAP;
             }
             // if still higher than cap cap, set to hard cap
             if ($damage_reduction > self::EVASION_HARD_CAP) {
@@ -1034,7 +1034,7 @@ class BattleManager {
 
             // if higher than soft cap, apply penalty
             if ($damage_reduction > self::EVASION_SOFT_CAP) {
-                $damage_reduction = (($damage_reduction - self::EVASION_SOFT_CAP) * self::EVASION_SOFT_CAP_RATIO) + $damage_reduction - self::EVASION_SOFT_CAP;
+                $damage_reduction = (($damage_reduction - self::EVASION_SOFT_CAP) * self::EVASION_SOFT_CAP_RATIO) + self::EVASION_SOFT_CAP;
             }
             // if still higher than cap cap, set to hard cap
             if ($damage_reduction > self::EVASION_HARD_CAP) {

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -94,6 +94,9 @@ abstract class Fighter {
 
     public $reputation_defense_boost = 0;
 
+    public $evasion_boost = 0;
+    public $resist_boost = 0;
+
     // Combat nerfs
     public $ninjutsu_nerf = 0;
     public $taijutsu_nerf = 0;
@@ -103,6 +106,9 @@ abstract class Fighter {
     public $speed_nerf = 0;
     public $intelligence_nerf = 0;
     public $willpower_nerf = 0;
+
+    public $evasion_nerf = 0;
+    public $resist_nerf = 0;
 
     // Getters
     abstract public function getName(): string;
@@ -328,7 +334,7 @@ abstract class Fighter {
         }
 
         $damage = round(
-          ($damage * (1 + $off_boost)) - $off_nerf, 
+          ($damage * (1 + $off_boost)) - $off_nerf,
           2
         );
         if($damage < 0) {
@@ -406,6 +412,23 @@ abstract class Fighter {
 
     public function getSpeed(bool $include_bloodline = false): float {
         return $include_bloodline ? $this->speed + $this->bloodline_speed_boost : $this->speed;
+    }
+
+    public function getBaseStatTotal(): int {
+        if ($this instanceof NPC) {
+            $rankManager = new RankManager($this->system);
+            $rankManager->loadRanks();
+            return $rankManager->statsForRankAndLevel($this->rank, $this->level);
+        }
+        $stat_total = $this->taijutsu_skill
+            + $this->ninjutsu_skill
+            + $this->genjutsu_skill
+            + (!empty($this->bloodline_skill) ? $this->bloodline_skill : 0)
+            + $this->willpower
+            + $this->intelligence
+            + $this->speed
+            + $this->cast_speed;
+        return max(1, $stat_total);
     }
 
     // Actions

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -8,7 +8,7 @@ abstract class Fighter {
 
     const SKILL_OFFENSE_RATIO = 0.10;
     const BLOODLINE_OFFENSE_RATIO = self::SKILL_OFFENSE_RATIO * 0.8;
-    const BLOODLINE_DEFENSE_MULTIPLIER = 35;
+    const BLOODLINE_DEFENSE_MULTIPLIER = 50;
 
     const SPEED_OFFENSE_RATIO = 0.25;
 
@@ -150,6 +150,7 @@ abstract class Fighter {
                     case 'ninjutsu_resist':
                     case 'genjutsu_resist':
                     case 'taijutsu_resist':
+                    case 'damage_resist':
                         $x = count($this->bloodline_defense_boosts);
                         $this->bloodline_defense_boosts[$x]['effect'] = $effect['effect'];
                         $this->bloodline_defense_boosts[$x]['effect_amount'] = $effect['effect_amount'];
@@ -360,7 +361,7 @@ abstract class Fighter {
             if (!empty($this->bloodline_defense_boosts)) {
                 foreach ($this->bloodline_defense_boosts as $id => $boost) {
                     $boost_type = explode('_', $boost['effect'])[0];
-                    if ($boost_type != $defense_type) {
+                    if ($boost_type != $defense_type && $boost_type != 'damage') {
                         continue;
                     }
 
@@ -419,6 +420,8 @@ abstract class Fighter {
             $rankManager = new RankManager($this->system);
             $rankManager->loadRanks();
             return $rankManager->statsForRankAndLevel($this->rank, $this->level);
+        } else if ($this instanceof User) {
+            return $this->total_stats;
         }
         $stat_total = $this->taijutsu_skill
             + $this->ninjutsu_skill

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -362,16 +362,7 @@ abstract class Fighter {
             $defense = 1;
         }
         if($apply_resists) {
-            $defense_boost = $this->defense_boost;
-            // if higher than soft cap, apply penalty
-            if ($defense_boost > self::RESIST_SOFT_CAP) {
-                $defense_boost = (($defense_boost - self::RESIST_SOFT_CAP) * self::RESIST_SOFT_CAP_RATIO) + self::RESIST_SOFT_CAP;
-            }
-            // if still higher than cap cap, set to hard cap
-            if ($defense_boost > self::RESIST_HARD_CAP) {
-                $defense_boost = self::RESIST_HARD_CAP;
-            }
-            $defense *= (1 + $defense_boost);
+            $defense *= (1 + $this->defense_boost);
             if (!empty($this->bloodline_defense_boosts)) {
                 foreach ($this->bloodline_defense_boosts as $id => $boost) {
                     $boost_type = explode('_', $boost['effect'])[0];
@@ -417,6 +408,18 @@ abstract class Fighter {
         $damage = round($raw_damage / $defense, 2);
         if($damage < 0.0) {
             $damage = 0;
+        }
+
+        if ($apply_resists) {
+            // if higher than soft cap, apply penalty
+            if ($this->resist_boost > self::RESIST_SOFT_CAP) {
+                $this->resist_boost = (($this->resist_boost - self::RESIST_SOFT_CAP) * self::RESIST_SOFT_CAP_RATIO) + self::RESIST_SOFT_CAP;
+            }
+            // if still higher than cap cap, set to hard cap
+            if ($this->resist_boost > self::RESIST_HARD_CAP) {
+                $this->resist_boost = self::RESIST_HARD_CAP;
+            }
+            $damage *= 1 - $this->resist_boost;
         }
         return $damage;
     }

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -15,6 +15,10 @@ abstract class Fighter {
     const MIN_RAND = 33;
     const MAX_RAND = 36;
 
+    const RESIST_SOFT_CAP = 0.5; // caps at 50% evasion
+    const RESIST_SOFT_CAP_RATIO = 0.5; // evasion beyond soft cap only 50% as effective
+    const RESIST_HARD_CAP = 0.75; // caps at 75% evasion
+
     public System $system;
 
     public string $combat_id;
@@ -358,7 +362,16 @@ abstract class Fighter {
             $defense = 1;
         }
         if($apply_resists) {
-            $defense *= (1 + $this->defense_boost);
+            $defense_boost = $this->defense_boost;
+            // if higher than soft cap, apply penalty
+            if ($defense_boost > self::RESIST_SOFT_CAP) {
+                $defense_boost = (($defense_boost - self::RESIST_SOFT_CAP) * self::RESIST_SOFT_CAP_RATIO) + self::RESIST_SOFT_CAP;
+            }
+            // if still higher than cap cap, set to hard cap
+            if ($defense_boost > self::RESIST_HARD_CAP) {
+                $defense_boost = self::RESIST_HARD_CAP;
+            }
+            $defense *= (1 + $defense_boost);
             if (!empty($this->bloodline_defense_boosts)) {
                 foreach ($this->bloodline_defense_boosts as $id => $boost) {
                     $boost_type = explode('_', $boost['effect'])[0];

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -352,16 +352,17 @@ abstract class Fighter {
      * @return float|int
      */
     public function calcDamageTaken($raw_damage, string $defense_type, bool $residual_damage = false, bool $apply_resists = true): float|int {
-        $defense = self::BASE_DEFENSE * (1 + $this->defense_boost);
+        $defense = self::BASE_DEFENSE;
 
         if($defense <= 0) {
             $defense = 1;
         }
         if($apply_resists) {
+            $defense *= (1 + $this->defense_boost);
             if (!empty($this->bloodline_defense_boosts)) {
                 foreach ($this->bloodline_defense_boosts as $id => $boost) {
                     $boost_type = explode('_', $boost['effect'])[0];
-                    if ($boost_type != $defense_type && $boost_type != 'damage') {
+                    if ($boost_type != $defense_type) {
                         continue;
                     }
 

--- a/pages/bloodline.php
+++ b/pages/bloodline.php
@@ -102,7 +102,7 @@ function bloodline() {
 			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] extra Genjutsu offense</span><br><span style='padding-left: 15px; font-size: smaller; font-style: italic'>Boost gradually  decreases to 75% strength as Bloodline Skill exceeds Genjutsu skill</span>"
 		),
 		'heal' => array(
-			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] to [AMOUNT2] per turn based on remaining health</span>"
+			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] per turn</span>"
 		),
 		'ninjutsu_resist' => array(
 			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] less Ninjutsu damage taken</span>"
@@ -114,7 +114,7 @@ function bloodline() {
 			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] less Taijutsu damage taken</span>"
 		),
         'damage_resist' => array(
-            'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] less damage taken per turn</span>"
+            'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] effective resist stat, [AMOUNT2]% less damage taken</span>"
         ),
 		'speed_boost' => array(
 			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'> [AMOUNT] extra Speed</span>"
@@ -207,15 +207,13 @@ function bloodline() {
                 case 'taijutsu_resist':
                 case 'genjutsu_resist':
                 case 'ninjutsu_resist':
-                case 'damage_resist':
 					$replace_array[2] = round(
                         ($boost['effect_amount'] * Fighter::BLOODLINE_DEFENSE_MULTIPLIER) / Fighter::BASE_DEFENSE,
                         0
                     );
                     break;
-                case 'heal':
-                    $replace_array[4] = round($replace_array[2] * (1 + Bloodline::HEAL_RANGE_PERCENT / 100), 0);
-                    $replace_array[2] = round($replace_array[2] * (1 - Bloodline::HEAL_RANGE_PERCENT / 100), 0);
+				case 'damage_resist':
+                    $replace_array[4] = round(($replace_array[2] / $player->total_stats) * 100, 0);
                     break;
             }
 

--- a/pages/bloodline.php
+++ b/pages/bloodline.php
@@ -69,7 +69,7 @@ function bloodline() {
 	$bloodline_ranks = array(4 => 'Lesser', 3 => 'Common', 2 => 'Elite', 1 => 'Legendary', 5 => 'Admin');
 	echo "<label style='width: 8.8em;font-weight:bold;'>Name:</label>" . $player->bloodline->name . "<br />
 		<label style='width: 8.8em;font-weight:bold;'>Rank:</label>" . $bloodline_ranks[$player->bloodline->rank] . "<br />
-		<label style='width: 8.8em;font-weight:bold;'>Bloodline skill:</label>" . $player->bloodline_skill . " (+100 Base)<br />";
+		<label style='width: 8.8em;font-weight:bold;'>Bloodline skill:</label>" . $player->bloodline_skill . "<br />";
 	echo "<br />";
 
 
@@ -102,17 +102,20 @@ function bloodline() {
 			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] extra Genjutsu offense</span><br><span style='padding-left: 15px; font-size: smaller; font-style: italic'>Boost gradually  decreases to 75% strength as Bloodline Skill exceeds Genjutsu skill</span>"
 		),
 		'heal' => array(
-			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] per turn</span>"
+			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] to [AMOUNT2] per turn based on remaining health</span>"
 		),
 		'ninjutsu_resist' => array(
-			'text' => "[BL_SKILL] * [RATIO] * [0.7] -> <span class='amount'>[AMOUNT] less Ninjutsu damage taken</span>"
+			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] less Ninjutsu damage taken</span>"
 		),
 		'genjutsu_resist' => array(
-			'text' => "[BL_SKILL] * [RATIO] * [0.7] -> <span class='amount'>[AMOUNT] less Genjutsu damage taken</span>"
+			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] less Genjutsu damage taken</span>"
 		),
 		'taijutsu_resist' => array(
-			'text' => "[BL_SKILL] * [RATIO] * [0.7] -> <span class='amount'>[AMOUNT] less Taijutsu damage taken</span>"
+			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] less Taijutsu damage taken</span>"
 		),
+        'damage_resist' => array(
+            'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'>[AMOUNT] less damage taken per turn</span>"
+        ),
 		'speed_boost' => array(
 			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'> [AMOUNT] extra Speed</span>"
 		),
@@ -129,7 +132,7 @@ function bloodline() {
 			'text' => "[BL_SKILL] * [RATIO] -> <span class='amount'> [AMOUNT] extra willpower</span>"
 		)
 	);
-	$bloodline_skill = 100 + $player->bloodline_skill;
+	$bloodline_skill = $player->bloodline_skill < 100 ? 100 : $player->bloodline_skill;
 
 	echo "
 	<style>
@@ -137,7 +140,7 @@ function bloodline() {
 		color:#00C000;
 	}
 	</style>";
-	$search_array = array('[BL_SKILL]', '[RATIO]', '[AMOUNT]', '[PERCENTAGE]');
+	$search_array = array('[BL_SKILL]', '[RATIO]', '[AMOUNT]', '[PERCENTAGE]', '[AMOUNT2]');
 	if($player->bloodline->passive_boosts) {
 		echo "
 		<label style='font-weight:bold;'>Passive boosts</label>
@@ -204,11 +207,16 @@ function bloodline() {
                 case 'taijutsu_resist':
                 case 'genjutsu_resist':
                 case 'ninjutsu_resist':
+                case 'damage_resist':
 					$replace_array[2] = round(
                         ($boost['effect_amount'] * Fighter::BLOODLINE_DEFENSE_MULTIPLIER) / Fighter::BASE_DEFENSE,
                         0
                     );
-					break;
+                    break;
+                case 'heal':
+                    $replace_array[4] = round($replace_array[2] * (1 + Bloodline::HEAL_RANGE_PERCENT / 100), 0);
+                    $replace_array[2] = round($replace_array[2] * (1 - Bloodline::HEAL_RANGE_PERCENT / 100), 0);
+                    break;
             }
 
             $replace_array[1] = round($replace_array[1], 3);


### PR DESCRIPTION
[Evasion Changes]

Speed/CSpeed converts to evasion (for their respective offense type) based on ratio to stat total.
- 0% investment = 0% evasion
- 35% investment = 35% evasion
- 50% investment = 50% evasion

Soft cap at 50%
Hard cap at 75%
Soft cap ratio 50% (any evasion higher than the soft cap is only 50% as effective)

Final evasion is calculated by comparing the evasion stat of both players. 
If Player 1 has 35% evasion, and Player 2 has 10% evasion, the end result is Player 1 with 25% evasion.

Evasion calculation factors in the difference between user's and opponent's stat total.
- e.g. Fighting an opponent with half of your stat total doubles your total evasion. 
- if it was based on your own stat total, gaining non-speed stats decreases your evasion
- if it was based on your own stat total, a player with less speed can have a higher evasion than you (and other weirdness)

ON RELEASE:
- Adjust all Speed Nerf jutsu to Evasion Nerf
- Optional: Adjust all Speed Boost jutsu to Evasion Boost
- Adjust AI stats if necessary

===========================================

Baseline for comparison:
Build 1: 50% Bloodline Skill, 50% Offense Skill
Build 2: 32% Bloodline Skill, 32% Offense Skill, 36% Speed Stat
e.g. 125k/125k (or 0/250k) vs 80k/80k/90k

Before Update: 35% Evasion
After Update: 36% Evasion

Typical matchups should see no statistical change.

===========================================

[Jutsu Changes]

Evasion Boost/Nerf add or subtract evasion rather than modify speed.
Jutsu will be updated to reflect the (current live) amount of evasion gained against an identical opponent.

How Evasion Boost/Nerf values below were determined:
e.g. Nerfing an opponent's speed by 10% is equivalent to decreasing their evasion by 5.22%
1000 vs 1000 => 1000 vs 900 with 10% nerf || thus 1000 / 900 = 1.11111 || (1.11111 - 1) * 0.47 (evasion ratio) = 0.0522
e.g. Increasing your own speed by 10% is equivalent to increasing your evasion by 4.7%
1000 vs 1000 => 1100 vs 1000 with 10% boost || thus 1100 / 1000 = 1.1 || (1.1 - 1) * 0.47 (evasion ratio) = 0.047

Effective changes to speed nerf jutsu:
33% Speed Nerf = 17% Evasion Nerf
25% Speed Nerf = 13% Evasion Nerf
18% Speed Nerf = 9% Evasion Nerf
10% Speed Nerf = 5% Evasion Nerf
(Note these values are against an opponent with equal speed, so these are the least impactful use cases)

Revised to even out the numbers and give small positive adjustment:
33% Speed Nerf = 20% Evasion Nerf
25% Speed Nerf = 15% Evasion Nerf
18% Speed Nerf = 10% Evasion Nerf
10% Speed Nerf = 5% Evasion Nerf (this is on a low-rank jutsu, should be replaced with jutsu overhaul)

Speed boost jutsu can either be changed to Evasion Boost, or kept as Speed/CSpeed Boost.
If kept as Speed/CSpeed Boost will be stronger for high speed builds specifically, which is fine. 

====================================

[Bloodline Boost Changes]

Speed/CSpeed: no change, is now the baseline for comparison
~~Damage Resist: new boost type, applies to all damage types, value now the same as Heal~~
Damage Resist: new boost type, applies to all damage types, scales as % similar to evasion
~~Heal: scales based on remaining HP, 25% weaker at full HP, 25% stronger at 0 HP, distinguishes itself from Resist~~
Heal: same as now, value rebalanced relative to speed/resist

Other:
- Decreased Heal/Resist ratio from 0.036 to 0.030 accounting for Speed BL effectiveness change
- Changed Bloodline Defense from 35 => 50 so we don't deal with an extra 0.7x multiplier, and can set Resist = Heal
- Made 100 base bloodline skill only apply when skill less than 100

ON RELEASE:
- Doing the math on 30 Off vs 25 Off BLs shows that 5 Off is worth 10 Spd/Cspd/Resist/Heal
- For all 25 Off BLs, increase defensive boost power from 15 => 20
- Terracotta Soldiers: 30 Off, 15 Tai Resist, 15 Nin Resist => 30 Off, 10 Resist
- Phantasmal Stalker: 30 Off, 15 Tai Resist, 15 Gen Resist => 30 Off, 10 Resist
- Ancient's Deception: 25 Off, 15 Heal => 25 Off 20 Heal
- Eyes of God: 30 Off, 15 Tai Resist, 15 Gen Resist => 30 Off, 10 Resist
- Smouldering Sands: 30 Off, 15 Tai Resist, 15 Nin Resist => 30 Off, 10 Resist
- Frigid Tundra: 25 Off, 15 CSpd => 25 Off, 20 CSpd
- Impregnable Defenses: 30 Off, 15 Tai Resist, 15 Nin Resist => 25 Off, 20 resist
- Godslayer: 30 Off, 15 Tai Resist, 15 Gen Resist => 30 Off, 10 Resist
- Weeping Skies: 25 Off, 15 Spd => 25 Off 20 Spd

======================================

Side note regarding average damage per turn, important for comparing BL bonuses:
- The standard build in the game is a 30 Off boost BL, with 80k BL skill, 80 Off skill, 90k speed
- A 125k/125k 0 speed build is roughly the same in terms of damage output
- Explosive Kunai Seal has a total power of 9.05 at lv100 factoring in Residual, neither high nor low and is the baseline for  Ninjutsu damage/turn
- Explosive Kunai Seal is roughly 73420 damage/use for a standard Nin build, which equates to 367100 damage after 5 uses, or a 6 turn fight with overkill