### PR TITLE
Simplify Genjutsu

### DIFF
--- a/classes/Jutsu.php
+++ b/classes/Jutsu.php
@@ -41,8 +41,8 @@ class Jutsu {
     const CHUUNIN_SCALE_MULTIPLIER = 1.4; // 2.9 => 3.9 = +34.4%
     const JONIN_SCALE_MULTIPLIER = 1.75; // 2.9 => 4.9 = +69%
 
-    // Genjutsu gets declared with full power and effect instead of a tradeoff between them, we balance in code
-    const GENJUTSU_ATTACK_POWER_MODIFIER = 0.55;
+    /* Genjutsu gets declared with full power and effect instead of a tradeoff between them, we balance in code
+    const GENJUTSU_ATTACK_POWER_MODIFIER = 0.55;*/
 
     public static array $elements = [
         self::ELEMENT_FIRE,

--- a/classes/Jutsu.php
+++ b/classes/Jutsu.php
@@ -156,10 +156,11 @@ class Jutsu {
         if($this->jutsu_type == Jutsu::TYPE_TAIJUTSU) {
             $this->range = 1;
         }
+        /*
         if($this->jutsu_type == Jutsu::TYPE_GENJUTSU && in_array($use_type, self::$attacking_use_types)) {
             $this->power = round($this->base_power * self::GENJUTSU_ATTACK_POWER_MODIFIER, 2);
             // $this->effect_only = true; // toggle this if you turn the power back to 1
-        }
+        }*/
 
         $this->effect = $effect;
 
@@ -234,7 +235,7 @@ class Jutsu {
         $is_genjutsu_attack = $this->jutsu_type == Jutsu::TYPE_GENJUTSU && in_array($this->use_type, self::$attacking_use_types);
 
         $this->power = $this->base_power
-            * ($is_genjutsu_attack ? self::GENJUTSU_ATTACK_POWER_MODIFIER : 1)
+            //* ($is_genjutsu_attack ? self::GENJUTSU_ATTACK_POWER_MODIFIER : 1)
             * (1 + ($this->level * $level_power_multiplier));
         $this->power = round($this->power, 2);
     }

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -308,12 +308,10 @@ abstract class Fighter {
             $offense = $extra_offense + 900;
         }
 
-
-        // Make up for genjutsu's delayed damage. This assumes fights are about 10 turns
+        /* Make up for genjutsu's delayed damage. This assumes fights are about 10 turns
         if($attack->jutsu_type == Jutsu::TYPE_GENJUTSU) {
             $offense *= 1.15;
-        }
-
+        }*/
 
         $rand = mt_rand(self::MIN_RAND, self::MAX_RAND);
         if($disable_randomness) {


### PR DESCRIPTION
- Removed 0.55x Genjutsu base power modifier
- Removed 1.15x Genjutsu damage modifier

All Genjutsu should be edited to 63.25% of current values (1 * 1.15 * 0.55 = 0.6325).
![image](https://github.com/elementum-games/shinobi-chronicles/assets/129538454/f3646e66-f4b7-4d35-ae88-58e4b7b55def)
