### PR TITLE
Speed Adjustments

### DIFF
--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -247,7 +247,7 @@ class BattleEffectsManager {
         else if($effect->effect == 'genjutsu_nerf' or $effect->effect == 'daze') {
             $target->genjutsu_nerf += $effect_amount;
         }
-        else if($effect->effect == 'speed_nerf' or $effect->effect == 'cripple') {
+        else if($effect->effect == 'speed_nerf') {
             $target->speed_nerf += $target->getSpeed(true) * ($effect->effect_amount / 100);
             $target->cast_speed_nerf += $target->getCastSpeed(true) * ($effect->effect_amount / 100);
 

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -12,9 +12,9 @@ class BattleManager {
     const SPEED_DAMAGE_REDUCTION_RATIO = 1; // e.g. 10% of your stats in speed = 10% evasion
     const CAST_SPEED_DAMAGE_REDUCTION_RATIO = 1; // e.g. 10% of your stats in speed = 10% evasion
     const MAX_EVASION_DAMAGE_REDUCTION = 0.5; // LEGACY
-    const EVASION_SOFT_CAP = 0.5; // caps at 50% evasion
+    const EVASION_SOFT_CAP = 0.35; // caps at 50% evasion
     const EVASION_SOFT_CAP_RATIO = 0.5; // evasion beyond soft cap only 50% as effective
-    const EVASION_HARD_CAP = 0.75; // caps at 75% evasion
+    const EVASION_HARD_CAP = 0.65; // caps at 75% evasion
 
     private System $system;
 


### PR DESCRIPTION
- Evasion Soft Cap: 50% => 35%
- Evasion Hard Cap: 50% => 65%
- Cripple: now works correctly (modifies Evasion)

Addresses issues with balance between high speed and low speed.

Expectations based on additional testing:
30/10 BL vs 25/20 BL = identical
80k/80k/90k vs 62.5k/62.5k/125k = identical
80k/80k/90k vs 125k/125k/0 = identical
Speed vs Resist BL = identical

After changing Evasion soft cap from 50% down to 35%:
125/125/0 vs 62.5/62.5/125 = identical

Note: 80/80/90k === 80k Bloodline Skill, 80k Offense Skill, 90k Speed/CSpeed