### PR TITLE
Bloodline Tuning

### DIFF
--- a/classes/Bloodline.php
+++ b/classes/Bloodline.php
@@ -149,12 +149,14 @@ class Bloodline {
     public function setBoostAmounts(
         int $user_rank,
         int $ninjutsu_skill, int $taijutsu_skill, int $genjutsu_skill, int $bloodline_skill,
-        int $base_stats, int $total_stats, int $stats_max_level,
+        int $base_stats,
+        int $total_stats,
+        int $stats_max_level,
         int $regen_rate
     ): void {
         $ratios = [
             'offense_boost' => 0.02,
-            'defense_boost' => 0.09,
+            'defense_boost' => 0.095,
             'speed_boost' => 0.08,
             'mental_boost' => 0.1,
             'heal' => 0.03,


### PR DESCRIPTION
Tuning bloodline bonuses to meet the following goals:
- Speed and Resist should result in equal match-ups when all other variables are accounted for
- Offensive and Defensive bloodlines should result in equal match-ups, regardless of bloodline investment
    - e.g. a Resist bloodline with 30 Off should have an even matchup against a Resist bloodline with 25 Off
    - this should remain true for high (250k) and average (90k) bloodline skill
- Builds with high bloodline investment should deal consistently less damage with shop jutsu
    - bloodline builds should fall behind in damage at a similar same rate against a balance build when using shop jutsu
    - if these values don't line up perfectly we can tune BL jutsu on a per-bloodline basis to account for it
 
Editor Changes:
 - 25/20 BLs => 25/18
     - Based on testing 18 is the sweet spot, so 5 Off == 8 Resist/Speed
 
Code Changes:
- Resist Boost ratio: 0.09 => 0.095
    - Based on testing 0.095 results in equal damage dealt/received versus Speed's 0.08
 
Test Results:
- 250/0/0k 18 Resist vs 250/0/0k 18 Speed
    - 11111 damage vs 11254 damage (1.2%)
- 250/0/0k 10 Resist vs 250/0/0k 10 Speed
    - 15689 damage vs 15782 damage (0.5%)
- 250/0/0k 18 Resist vs 250/0/0k 10 Resist
    - 12676 damage vs 12289 damage (3.1%)
- 250/0/0k 18 Speed vs 250/0/0k 10 Speed
    - 17103 damage vs 16951 damage (0.8%)
- 80/80/90k 18 Resist vs 80/80/90k 18 Speed
    - 13874 damage vs 13991 damage (0.8%)
- 80/80/90k 10 Resist vs 80/80/90k 10 Speed
    - 15711 damage vs 15775 damage (0.4%)
- 80/80/90k 18 Resist vs 80/80/90k 10 Resist
    - 14319 damage vs 14728 damage (2.9%)
- 80/80/90k 18 Speed vs 80/80/90k 10 Speed
    - 15711 damage vs 16124 damage (2.6%)
- 80/80/90k 18 Resist vs 250/0/0k 18 Speed
    - 15246 damage vs 14165 damage (7.6%)
- 80/80/90k 18 Speed vs 250/0/0k 18 Resist
    - 10338 damage vs 9390 damage (10%)
- 80/80/90k 10 Resist vs 250/0/0k 18 Speed
    - 16538 damage vs 14938 damage (11%)
- 80/80/90k 10 Speed vs 250/0/0k 18 Resist
    - 11052 damage vs 9703 damage (14%)
- 80/80/90k 10 Speed vs 250/0/0k 18 Speed
    - 10409 damage vs 9270 damage (12%)
- 80/80/90k 10 Resist vs 250/0/0k 18 Resist
    - 17039 damage vs 15268 damage (12%)