### PR TITLE
Combat v1.2 updates 4

### DIFF
--- a/admin/constraints/jutsu.php
+++ b/admin/constraints/jutsu.php
@@ -42,6 +42,8 @@ $jutsu_effects = [
     'counter',
     'immolate',
     'recoil',
+    'delayed_residual',
+    'reflect',
 ];
 
 $ranks = [];

--- a/admin/entity_constraints.php
+++ b/admin/entity_constraints.php
@@ -230,7 +230,7 @@ $constraints['ai'] = [
             'use_type' => [
                 'data_type' => 'string',
                 'input_type' => 'text',
-                'options' => [Jutsu::USE_TYPE_MELEE, Jutsu::USE_TYPE_PROJECTILE, Jutsu::USE_TYPE_BUFF, Jutsu::USE_TYPE_BARRIER],
+                'options' => [Jutsu::USE_TYPE_MELEE, Jutsu::USE_TYPE_PROJECTILE, Jutsu::USE_TYPE_BUFF, Jutsu::USE_TYPE_BARRIER, Jutsu::USE_TYPE_INDIRECT],
             ],
             'effect' => [
                     'data_type' => 'string',
@@ -277,6 +277,8 @@ $constraints['ai'] = [
                         'counter',
                         'immolate',
                         'recoil',
+                        'delayed_residual',
+                        'reflect',
                     ],
             ],
             'effect_amount' => [

--- a/classes/Jutsu.php
+++ b/classes/Jutsu.php
@@ -30,6 +30,7 @@ class Jutsu {
     const USE_TYPE_REMOTE_SPAWN = 'spawn';
     const USE_TYPE_BUFF = 'buff';
     const USE_TYPE_BARRIER = 'barrier';
+    const USE_TYPE_INDIRECT = 'indirect';
 
     const TARGET_TYPE_FIGHTER_ID = 'fighter_id';
     const TARGET_TYPE_TILE = 'tile';
@@ -59,6 +60,7 @@ class Jutsu {
         self::USE_TYPE_REMOTE_SPAWN,
         self::USE_TYPE_BUFF,
         self::USE_TYPE_BARRIER,
+        self::USE_TYPE_INDIRECT,
     ];
 
     public static array $attacking_use_types = [

--- a/classes/battle/BattleActionProcessor.php
+++ b/classes/battle/BattleActionProcessor.php
@@ -180,7 +180,7 @@ class BattleActionProcessor {
         }
         else if($action->jutsu_purchase_type == Jutsu::PURCHASE_TYPE_PURCHASABLE) {
             $jutsu = $fighter->jutsu[$action->jutsu_id] ?? null;
-        } 
+        }
         else if ($action->jutsu_purchase_type == Jutsu::PURCHASE_TYPE_EVENT_SHOP) {
             $jutsu = $fighter->jutsu[$action->jutsu_id] ?? null;
         }
@@ -267,7 +267,7 @@ class BattleActionProcessor {
             }
         }
 
-        if($attack->jutsu->isAllyTargetType()) {
+        if($attack->jutsu->isAllyTargetType() || $attack->jutsu->use_type == Jutsu::USE_TYPE_INDIRECT) {
             $attack->jutsu->weapon_id = 0;
             $attack->jutsu->effect_only = true;
         }

--- a/classes/battle/BattleAttack.php
+++ b/classes/battle/BattleAttack.php
@@ -10,6 +10,8 @@ class BattleAttack {
     public float $piercing_percent = 0;
     public float $substitution_percent = 0;
     public float $counter_percent = 0;
+    public float $reflect_percent = 0;
+    public float $reflect_duration = 0;
     public float $immolate_percent = 0;
     public float $immolate_raw_damage = 0;
     public float $recoil_percent = 0;
@@ -17,4 +19,6 @@ class BattleAttack {
     public float $countered_percent = 0; // opponent's counter
     public float $countered_raw_damage = 0; // damage dealt from opponent
     public string $countered_jutsu_type; // jutsu type of opponent's counter
+    public float $reflected_percent = 0; // opponent's counter
+    public float $reflected_raw_damage = 0; // damage dealt from opponent
 }

--- a/classes/battle/BattleEffect.php
+++ b/classes/battle/BattleEffect.php
@@ -4,7 +4,12 @@ class BattleEffect {
     public static array $buff_effects = [
         'heal','ninjutsu_boost','taijutsu_boost','genjutsu_boost',
         'cast_speed_boost','speed_boost','lighten','intelligence_boost','willpower_boost',
-        'ninjutsu_resist','genjutsu_resist','taijutsu_resist','harden','evasion_boost','resist_boost'
+        'ninjutsu_resist','genjutsu_resist','taijutsu_resist','harden','evasion_boost','resist_boost',
+        'fire_boost',
+        'wind_boost',
+        'lightning_boost',
+        'earth_boost',
+        'water_boost',
     ];
 
     // combat id
@@ -58,6 +63,6 @@ class BattleEffect {
             power: $raw_data['power'] ?? 0,
             first_turn: $raw_data['first_turn'] ?? false,
             layer_active: $raw_data['layer_active'] ?? false,
-        );    
+        );
     }
 }

--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -94,11 +94,11 @@ class BattleEffectsManager {
             case 'lightning_boost':
             case 'earth_boost':
             case 'water_boost':
-            case 'fire_weakness':
-            case 'wind_weakness':
-            case 'lightning_weakness':
-            case 'earth_weakness':
-            case 'water_weakness':
+            case 'fire_vulnerability':
+            case 'wind_vulnerability':
+            case 'lightning_vulnerability':
+            case 'earth_vulnerability':
+            case 'water_vulnerability':
                 // No changes needed to base number, calculated in applyPassiveEffects
                 break;
             case 'intelligence_boost':

--- a/classes/battle/BattleEffectsManager.php
+++ b/classes/battle/BattleEffectsManager.php
@@ -53,6 +53,7 @@ class BattleEffectsManager {
 
         switch ($effect->effect) {
             case 'residual_damage':
+            case 'delayed_residual':
             case 'ninjutsu_nerf':
             case 'taijutsu_nerf':
             case 'genjutsu_nerf':
@@ -87,6 +88,7 @@ class BattleEffectsManager {
             case 'piercing':
             case 'immolate':
             case 'recoil':
+            case 'reflect':
             case 'fire_boost':
             case 'wind_boost':
             case 'lightning_boost':
@@ -107,6 +109,9 @@ class BattleEffectsManager {
                 break;
             case Jutsu::USE_TYPE_BARRIER:
                 $effect->effect_amount = $raw_damage;
+                break;
+            case 'reflect_damage':
+                // No changes need to base number, calculated in jutsu collision
                 break;
             default:
                 $apply_effect = false;
@@ -423,7 +428,7 @@ class BattleEffectsManager {
             return false;
         }
 
-        if($effect->effect == 'residual_damage' || $effect->effect == 'bleed') {
+        if($effect->effect == 'residual_damage' || $effect->effect == 'bleed' || $effect->effect == 'delayed_residual' || $effect->effect == 'reflect_damage') {
             $damage = $target->calcDamageTaken($effect->effect_amount, $effect->damage_type, true);
             $residual_damage_raw = $target->calcDamageTaken($effect->effect_amount, $effect->damage_type, true, apply_resists: false);
             $residual_damage_resisted = $residual_damage_raw - $damage;
@@ -548,6 +553,7 @@ class BattleEffectsManager {
                 $announcement_text = "[opponent]'s Speed is being lowered" . $effect_details;
                 break;
             case 'residual_damage':
+            case 'delayed_residual':
                 $announcement_text = "[opponent] is taking Residual Damage" . $effect_details;
                 break;
             case 'drain_chakra':
@@ -693,7 +699,7 @@ class BattleEffectsManager {
     public function processImmolate(BattleAttack $battleAttack, Fighter $target): int {
         $immolate_raw_damage = 0;
         foreach ($this->active_effects as $index => $effect) {
-            if ($effect->effect == 'residual_damage' && $effect->target == $target->combat_id) {
+            if (($effect->effect == 'residual_damage' || $effect->effect == 'bleed' || $effect->effect == 'delayed_residual' || $effect->effect == 'reflect_damage') && $effect->target == $target->combat_id) {
                 $immolate_raw_damage += ($effect->turns * $effect->effect_amount);
                 unset($this->active_effects[$index]);
             }

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -825,8 +825,8 @@ class BattleManager {
         }*/
 
         if(empty($attack->jutsu->effect_only)) {
-            $attack_damage = $target->calcDamageTaken($attack->raw_damage, $attack->jutsu->jutsu_type);
-            $attack_damage_raw = $target->calcDamageTaken($attack->raw_damage, $attack->jutsu->jutsu_type, apply_resists : false);
+            $attack_damage = $target->calcDamageTaken($attack->raw_damage, $attack->jutsu->jutsu_type, element: $attack->jutsu->element);
+            $attack_damage_raw = $target->calcDamageTaken($attack->raw_damage, $attack->jutsu->jutsu_type, apply_resists : false, element: $attack->jutsu->element);
             $damage_resisted = round($attack_damage_raw - $attack_damage, 2);
 
             $target->health -= $attack_damage;
@@ -989,7 +989,6 @@ class BattleManager {
         if (!empty($player1_jutsu->element)) {
             switch (strtolower($player1_jutsu->element)) {
                 case 'fire':
-                    $player1_elemental_damage_modifier *= 1 + $player2->fire_weakness;
                     if (!empty($player2_jutsu->element) && strtolower($player2_jutsu->element) == 'water') {
                         $player1_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player1->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1000,7 +999,6 @@ class BattleManager {
                     }
                     break;
                 case 'wind':
-                    $player1_elemental_damage_modifier *= 1 + $player2->wind_weakness;
                     if (!empty($player2_jutsu->element) && strtolower($player2_jutsu->element) == 'fire') {
                         $player1_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player1->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1011,7 +1009,6 @@ class BattleManager {
                     }
                     break;
                 case 'lightning':
-                    $player1_elemental_damage_modifier *= 1 + $player2->lightning_weakness;
                     if (!empty($player2_jutsu->element) && strtolower($player2_jutsu->element) == 'wind') {
                         $player1_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player1->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1022,7 +1019,6 @@ class BattleManager {
                     }
                     break;
                 case 'earth':
-                    $player1_elemental_damage_modifier *= 1 + $player2->earth_weakness;
                     if (!empty($player2_jutsu->element) && strtolower($player2_jutsu->element) == 'lightning') {
                         $player1_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player1->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1033,7 +1029,6 @@ class BattleManager {
                     }
                     break;
                 case 'water':
-                    $player1_elemental_damage_modifier *= 1 + $player2->water_weakness;
                     if (!empty($player2_jutsu->element) && strtolower($player2_jutsu->element) == 'earth') {
                         $player1_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player1->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1050,7 +1045,6 @@ class BattleManager {
         if (!empty($player2_jutsu->element)) {
             switch (strtolower($player2_jutsu->element)) {
                 case 'fire':
-                    $player2_elemental_damage_modifier *= 1 + $player1->fire_weakness;
                     if (!empty($player1_jutsu->element) && strtolower($player1_jutsu->element) == 'water') {
                         $player2_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player2->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1061,7 +1055,6 @@ class BattleManager {
                     }
                     break;
                 case 'wind':
-                    $player2_elemental_damage_modifier *= 1 + $player1->fire_weakness;
                     if (!empty($player1_jutsu->element) && strtolower($player1_jutsu->element) == 'fire') {
                         $player2_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player2->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1072,7 +1065,6 @@ class BattleManager {
                     }
                     break;
                 case 'lightning':
-                    $player2_elemental_damage_modifier *= 1 + $player1->fire_weakness;
                     if (!empty($player1_jutsu->element) && strtolower($player1_jutsu->element) == 'wind') {
                         $player2_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player2->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1083,7 +1075,6 @@ class BattleManager {
                     }
                     break;
                 case 'earth':
-                    $player2_elemental_damage_modifier *= 1 + $player1->fire_weakness;
                     if (!empty($player1_jutsu->element) && strtolower($player1_jutsu->element) == 'lightning') {
                         $player2_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player2->barrier *= 1 - $elemental_clash_damage_modifier;
@@ -1094,7 +1085,6 @@ class BattleManager {
                     }
                     break;
                 case 'water':
-                    $player2_elemental_damage_modifier *= 1 + $player1->fire_weakness;
                     if (!empty($player1_jutsu->element) && strtolower($player1_jutsu->element) == 'earth') {
                         $player2_elemental_damage_modifier *= 1 - $elemental_clash_damage_modifier;
                         $player2->barrier *= 1 - $elemental_clash_damage_modifier;

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -1350,7 +1350,7 @@ class BattleManager {
             $player1_attack->counter_percent *= (1 - $player2_attack->piercing_percent);
             // Apply reduction
             $player2_attack->countered_percent = $player1_attack->counter_percent;
-            $player2_attack->countered_raw_damage = $player2_damage * (1 - $player1_attack->counter_percent);
+            $player2_attack->countered_raw_damage = $player2_damage * $player1_attack->counter_percent;
             $player2_attack->countered_jutsu_type = $player1_attack->jutsu->jutsu_type;
             $player2_damage *= (1 - $player1_attack->counter_percent);
             // Set display
@@ -1365,7 +1365,7 @@ class BattleManager {
             $player2_attack->counter_percent *= (1 - $player1_attack->piercing_percent);
             // Apply reduction
             $player1_attack->countered_percent = $player2_attack->counter_percent;
-            $player1_attack->countered_raw_damage = $player1_damage * (1 - $player2_attack->counter_percent);
+            $player1_attack->countered_raw_damage = $player1_damage *  $player2_attack->counter_percent;
             $player1_attack->countered_jutsu_type = $player2_attack->jutsu->jutsu_type;
             $player1_damage *= (1 - $player2_attack->counter_percent);
             // Set display

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -882,7 +882,7 @@ class BattleManager {
                 $text .= "<b><span class=\"battle_text_{$attack->jutsu->jutsu_type}\" style=\"color:{$attack_jutsu_color}\"><i>" . System::unSlug($attack->jutsu->name) . " / " . System::unSlug($user->items[$attack->jutsu->weapon_id]->name) . "</br>" . '</i></span></b>';
             } else {
                 if ($attack->jutsu->element != Jutsu::ELEMENT_NONE && $attack->jutsu->element != "none") {
-                    $text .= "<b><span class=\"battle_text_{$attack->jutsu->jutsu_type}\" style=\"color:{$attack_jutsu_color}\"><i>" . System::unSlug($attack->jutsu->element) . " Release: " . System::unSlug($attack->jutsu->name) . '</i></span></b></br>';
+                    $text .= "<b><span class=\"battle_text_{$attack->jutsu->jutsu_type}\" style=\"color:{$attack_jutsu_color}\"><i>" . System::unSlug($attack->jutsu->element) . " Style: " . System::unSlug($attack->jutsu->name) . '</i></span></b></br>';
                 } else {
                     $text .= "<b><span class=\"battle_text_{$attack->jutsu->jutsu_type}\" style=\"color:{$attack_jutsu_color}\"><i>" . System::unSlug($attack->jutsu->name) . '</i></span></b></br>';
                 }

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -1378,8 +1378,6 @@ class BattleManager {
             $player2_attack->reflected_percent = $player1_attack->reflect_percent;
             $player2_attack->reflected_raw_damage = $player2_damage * $player1_attack->reflect_percent;
             $player2_damage *= (1 - $player1_attack->reflect_percent);
-            // Set residual
-            $player1_jutsu->effects[] = new Effect('reflect_damage', $player2_attack->reflected_raw_damage / $player1_attack->reflect_duration, $player1_attack->reflect_duration);
             // Set display
             $block_percent = round($player1_attack->reflect_percent * 100, 0);
             if (!empty($collision_text)) {
@@ -1394,14 +1392,26 @@ class BattleManager {
             $player1_attack->reflected_percent = $player2_attack->reflect_percent;
             $player1_attack->reflected_raw_damage = $player1_damage *  $player2_attack->reflect_percent;
             $player1_damage *= (1 - $player2_attack->reflect_percent);
-            // Set residual
-            $player2_jutsu->effects[] = new Effect('reflect_damage', $player1_attack->reflected_raw_damage / $player2_attack->reflect_duration, $player2_attack->reflect_duration);
             // Set display
             $block_percent = round($player2_attack->reflect_percent * 100, 0);
             if (!empty($collision_text)) {
                 $collision_text .= "[br]";
             }
             $collision_text .= "[opponent] reflected $block_percent% of [player]'s damage!";
+        }
+
+        // cap reflect/counter based on the jutsu used
+        $player2_attack->reflected_raw_damage = min($player2_attack->reflected_raw_damage, $player1_damage);
+        $player1_attack->reflected_raw_damage = min($player1_attack->reflected_raw_damage, $player2_damage);
+        $player2_attack->countered_raw_damage = min($player2_attack->countered_raw_damage, $player1_damage);
+        $player1_attack->countered_raw_damage = min($player1_attack->countered_raw_damage, $player2_damage);
+
+        // set reflect damage
+        if ($player1_attack->reflect_percent > 0) {
+            $player1_jutsu->effects[] = new Effect('reflect_damage', $player2_attack->reflected_raw_damage / $player1_attack->reflect_duration, $player1_attack->reflect_duration);
+        }
+        if ($player2_attack->reflect_percent > 0) {
+            $player2_jutsu->effects[] = new Effect('reflect_damage', $player1_attack->reflected_raw_damage / $player2_attack->reflect_duration, $player2_attack->reflect_duration);
         }
 
         return $this->parseCombatText($collision_text, $player1, $player2);

--- a/classes/battle/Fighter.php
+++ b/classes/battle/Fighter.php
@@ -482,10 +482,6 @@ abstract class Fighter {
             $raw_damage *= (100 - $this->reputation_defense_boost) / 100;
         }
 
-        if($this instanceof NPC && $defense_type == 'genjutsu') {
-            $defense *= 0.8;
-        }
-
         $damage = round($raw_damage / $defense, 2);
         if($damage < 0.0) {
             $damage = 0;

--- a/classes/notification/NotificationAPIManager.php
+++ b/classes/notification/NotificationAPIManager.php
@@ -258,12 +258,15 @@ class NotificationAPIManager {
         //Battle
         if ($this->player->battle_id > 0) {
             $result = $this->system->db->query(
-                "SELECT `battle_type` FROM `battles` WHERE `battle_id`='{$this->player->battle_id}' LIMIT 1"
+                "SELECT `battle_type`, `winner` FROM `battles` WHERE `battle_id`='{$this->player->battle_id}' LIMIT 1"
             );
             if ($this->system->db->last_num_rows == 0) {
                 $this->player->battle_id = 0;
             } else {
                 $result = $this->system->db->fetch($result);
+                if ($result['winner'] == 'STOP') {
+                    $this->player->battle_id = 0;
+                }
                 $link = null;
                 switch ($result['battle_type']) {
                     case Battle::TYPE_AI_ARENA:


### PR DESCRIPTION
- Add "Reflect" tag, essentially a Counter that turns incoming damage into a residual
    - Will lean into the Genjutsu playstyle of using residuals as a resource to empower other jutsu
- Add "Delayed Residual" tag, effectively Piercing but for jutsu with lower base power (e.g. Lightning Genjutsu)
- Reworked Immolate to ONLY convert residuals into power for the jutsu
    - Keeps Genjutsu more interactive so both players can play around Immolate effects
    - Lets us use Immolate as more than a combo finisher, residuals become a resource
- Capped Counter/Reflect damage to that of the counter
    - e.g. a Counter that deals 30k direct damage can only deal 30k additional counter damage (in terms of raw damage)
- Fixed elemental tags
- Fixed bug that could cause players to be stuck in combat

Idea behind these changes is so that Gen is more interactive both ways while still focusing on residuals. 

Current playstyle:
- Debuff
- Long Residual
- Medium Residual
- Vulnerability
- Immolate

This is functional but battles become a damage race with little variations in fights.

New sample playstyle:
- Medium Residual (deal damage and prepare to empower other jutsu)
- Reflect (reduce an opponent's early combo and set yourself up)
- Immolate Residual (combo extender, uses previous two residuals to create a stronger one)
- Vulnerability (set up for burst turn)
- Delayed Residual (opponent predicts the burst and uses a Counter, predict this and bypass)

This creates opportunities on both sides for players to interact, less predetermined outcomes.
Hopefully Genjutsu will be more comparable to Nin/Tai while retaining its own identity.
