### PR TITLE
battle qol

### DIFF
--- a/style/new_geisha/new_geisha.css
+++ b/style/new_geisha/new_geisha.css
@@ -700,9 +700,9 @@ a#spec_miss_cancel {
     #container {
         flex-direction: column !important;
         padding-bottom: 0px;
-        transform: scale(1.35);
+        transform: scale(1.2);
         transform-origin: top left;
-        width: calc(100% / 1.35) !important;
+        width: calc(100% / 1.2) !important;
         margin-left: 0;
     }
     #footer {

--- a/style/new_geisha/new_geisha.css
+++ b/style/new_geisha/new_geisha.css
@@ -810,6 +810,9 @@ button {
         color: var(--font-color-2);
         border-color: var(--font-color-2);
     }
+#handsealOverlay {
+    background-color: var(--sidebar-button-background-color) !important;
+}
 #jutsu .jutsuList {
     display: flex;
     flex-wrap: wrap;
@@ -830,6 +833,7 @@ button {
     flex-direction: column;
     gap: 1px;
     user-select: none;
+    overflow: hidden;
 }
     #jutsu .jutsuName:hover {
         background: #221920 !important;
@@ -844,6 +848,8 @@ button {
         color: #d2cbef;
         font-size: 16px;
         font-weight: bold;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName .jutsu_type {
         font-family: var(--font-secondary);
@@ -856,17 +862,23 @@ button {
         font-family: var(--font-secondary);
         color: #eee1c8;
         font-size: 12px;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName .jutsu_details_row {
         display: flex;
         justify-content: space-between;
         text-align: center;
         margin-bottom: 5px;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName .jutsu_effect {
         display: flex;
         justify-content: space-between;
         text-align: center;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName[aria-disabled='true'] {
         opacity: 0.5;

--- a/style/new_geisha/new_geisha.css
+++ b/style/new_geisha/new_geisha.css
@@ -816,7 +816,7 @@ button {
 #jutsu .jutsuList {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-evenly;
+    justify-content: center;
     margin-bottom: 30px;
     box-sizing: border-box;
     padding-top: 20px;
@@ -834,6 +834,7 @@ button {
     gap: 1px;
     user-select: none;
     overflow: hidden;
+    outline: #20222b 1px solid;
 }
     #jutsu .jutsuName:hover {
         background: #221920 !important;

--- a/style/sumu/sumu.css
+++ b/style/sumu/sumu.css
@@ -838,10 +838,7 @@ a#spec_miss_cancel {
     #container {
         flex-direction: column !important;
         padding-bottom: 0px;
-        transform: scale(1.35);
-        transform-origin: top left;
-        width: calc(100% / 1.35) !important;
-        margin-left: 0;
+        width: 100%;
     }
 
     #footer {
@@ -866,6 +863,9 @@ a#spec_miss_cancel {
     #content {
         width: 100%;
     }
+        #content::after {
+            background: none;
+        }
 
     .sb_header_bar::after {
         display: none;

--- a/style/sumu/sumu.css
+++ b/style/sumu/sumu.css
@@ -949,6 +949,9 @@ button {
         color: var(--font-color-2);
         border-color: var(--font-color-2);
     }
+#handsealOverlay {
+    background-color: var(--sidebar-button-background-color) !important;
+}
 #jutsu .jutsuList {
     display: flex;
     flex-wrap: wrap;

--- a/style/sumu/sumu.css
+++ b/style/sumu/sumu.css
@@ -955,7 +955,7 @@ button {
 #jutsu .jutsuList {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-evenly;
+    justify-content: center;
     margin-bottom: 30px;
     box-sizing: border-box;
     padding-top: 20px;
@@ -974,6 +974,7 @@ button {
     gap: 1px;
     outline: 1px solid #E0E0E0;
     user-select: none;
+    overflow: hidden;
 }
     #jutsu .jutsuName:hover {
         background: var(--box-color-default) !important;
@@ -988,6 +989,8 @@ button {
         color: #6e0e11;
         font-size: 16px;
         font-weight: bold;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName .jutsu_type {
         font-family: var(--font-secondary);
@@ -1000,17 +1003,23 @@ button {
         font-family: var(--font-secondary);
         color: var(--font-color-2);
         font-size: 12px;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName .jutsu_details_row {
         display: flex;
         justify-content: space-between;
         text-align: center;
         margin-bottom: 5px;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName .jutsu_effect {
         display: flex;
         justify-content: space-between;
         text-align: center;
+        overflow: hidden;
+        white-space: nowrap;
     }
     #jutsu .jutsuName[aria-disabled='true'] {
         opacity: 0.5;

--- a/templates/battle/action_prompt.php
+++ b/templates/battle/action_prompt.php
@@ -188,6 +188,9 @@ $prefill_item_id = $_POST['item_id'] ?? '';
         var currentlySelectedJutsu = false;
         var lastJutsu, firstJutsu = false;
         $('.jutsuName').click(function(){
+            if (lastJutsu == this) {
+                document.getElementById('submitbtn').click();
+            }
 
             if(lastJutsu !== this && firstJutsu) {
 
@@ -288,12 +291,10 @@ $prefill_item_id = $_POST['item_id'] ?? '';
         });
         $('#jutsu .taijutsu').click(function(){
             if(display_state !== 'taijutsu') {
-                $('#textPrompt').text(weapons_prompt);
-                $('#handSeals').hide();
-                $('#weapons').show();
-                if(display_state === 'bloodline_jutsu') {
-                    $('#handsealOverlay').fadeOut();
-                }
+                //$('#textPrompt').text(weapons_prompt);
+                //$('#handSeals').hide();
+                //$('#weapons').show();
+                $('#handsealOverlay').fadeIn();
             }
             display_state = 'taijutsu';
             $('#jutsuType').val('taijutsu');
@@ -462,13 +463,6 @@ $prefill_item_id = $_POST['item_id'] ?? '';
                             <div class="jutsu_details">
                                 <div class="jutsu_details_row">
                                     <span class="jutsu_details_power">Power: <?= round($attack->power, 2) ?></span>
-                                    <span class="jutsu_details_cooldown">
-                                        <?php if ($cd_left > 0): ?>
-                                                CD: (<?= $cd_left ?>) <?= $attack->cooldown ?> turns
-                                        <?php else: ?>
-                                                CD: <?= $attack->cooldown ?> turns
-                                        <?php endif; ?>
-                                    </span>
                                 </div>
                                 <?php foreach ($attack->effects as $effect): ?>
                                         <div class="jutsu_effect">

--- a/templates/battle/action_prompt.php
+++ b/templates/battle/action_prompt.php
@@ -439,6 +439,12 @@ $prefill_item_id = $_POST['item_id'] ?? '';
             <?php else: ?>
                 <p style='text-align:center;'>You do not have any healing items.</p>
             <?php endif; ?>
+            <form action='<?= $self_link ?>' method='post'>
+                <input type='hidden' id='itemID' name='item_id' value='<?= $prefill_item_id ?>' />
+                <p style='display:block;text-align:center;margin:auto;'>
+                    <input id='submitbtn' type='submit' name='attack' value='Submit' />
+                </p>
+            </form>
         </div>
     </td></tr>
 <?php else: ?>

--- a/templates/battle/action_prompt.php
+++ b/templates/battle/action_prompt.php
@@ -533,51 +533,53 @@ $prefill_item_id = $_POST['item_id'] ?? '';
                             <?php $c2_count = 0; ?>
                     <?php endif; ?>
                 <?php endfor; ?>
-                <!-- Display bloodline jutsu-->
-                <?php if ($player->bloodline_id): ?>
-                    <?php if (!empty($player->bloodline->jutsu)): ?>
-                                <?php foreach ($player->bloodline->jutsu as $id => $jutsu): ?>
-                                            <?php
-                                            $jutsu->setCombatId($player->combat_id);
-                                            $cd_left = $battle->jutsu_cooldowns[$jutsu->combat_id] ?? 0;
-                                            ?>
+                    </div>
+                    <!-- Display bloodline jutsu-->
+                    <?php if ($player->bloodline_id): ?>
+                            <?php if (!empty($player->bloodline->jutsu)): ?>
+                                    <div class="jutsuList">
+                                            <?php foreach ($player->bloodline->jutsu as $id => $jutsu): ?>
+                                                            <?php
+                                                            $jutsu->setCombatId($player->combat_id);
+                                                            $cd_left = $battle->jutsu_cooldowns[$jutsu->combat_id] ?? 0;
+                                                            ?>
 
-                                            <div id='bloodline<?= $c3_count ?>' class='jutsuName bloodline_jutsu' data-handseals='<?= $jutsu->hand_seals ?>' data-id='<?= $id ?>' aria-disabled='<?= ($cd_left > 0 ? "true" : "false") ?>'>
-                                                <span class="jutsu_name"><?= $jutsu->name ?></span>
-                                                <span class="jutsu_type"><?php echo "bloodline " . ($jutsu->hasElement() ? System::unSlug($jutsu->jutsu_type) . " - " . $jutsu->element : System::unSlug($jutsu->jutsu_type)) ?></span>
-                                                <div class="jutsu_details">
-                                                    <div class="jutsu_details_row">
-                                                        <span class="jutsu_details_power">Power: <?= round($jutsu->power, 2) ?></span>
-                                                        <span class="jutsu_details_cooldown">
-                                                            <?php if ($cd_left > 0): ?>
-                                                                    CD: (<?= $cd_left ?>) <?= $jutsu->cooldown ?> turns
-                                                            <?php else: ?>
-                                                                    CD: <?= $jutsu->cooldown ?> turns
-                                                            <?php endif; ?>
-                                                        </span>
-                                                    </div>
-                                                    <?php foreach ($jutsu->effects as $effect): ?>
-                                                            <div class="jutsu_effect">
-                                                                <?php
-                                                                if ($effect->effect != "none") {
-                                                                    echo in_array($effect->effect, ["substitution", "counter", "piercing", "recoil"])
-                                                                        ? System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%)"
-                                                                        : (($effect->effect == "none" && $jutsu->use_type == Jutsu::USE_TYPE_BARRIER)
-                                                                            ? "Barrier"
-                                                                            : System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
-                                                                                ? $effect->effect_length . " turn)"
-                                                                                : $effect->effect_length . " turns)"));
-                                                                }
-                                                                ?>
+                                                            <div id='bloodline<?= $c3_count ?>' class='jutsuName bloodline_jutsu' data-handseals='<?= $jutsu->hand_seals ?>' data-id='<?= $id ?>' aria-disabled='<?= ($cd_left > 0 ? "true" : "false") ?>'>
+                                                                <span class="jutsu_name"><?= $jutsu->name ?></span>
+                                                                <span class="jutsu_type"><?php echo "bloodline " . ($jutsu->hasElement() ? System::unSlug($jutsu->jutsu_type) . " - " . $jutsu->element : System::unSlug($jutsu->jutsu_type)) ?></span>
+                                                                <div class="jutsu_details">
+                                                                    <div class="jutsu_details_row">
+                                                                        <span class="jutsu_details_power">Power: <?= round($jutsu->power, 2) ?></span>
+                                                                        <span class="jutsu_details_cooldown">
+                                                                            <?php if ($cd_left > 0): ?>
+                                                                                        CD: (<?= $cd_left ?>) <?= $jutsu->cooldown ?> turns
+                                                                            <?php else: ?>
+                                                                                        CD: <?= $jutsu->cooldown ?> turns
+                                                                            <?php endif; ?>
+                                                                        </span>
+                                                                    </div>
+                                                                    <?php foreach ($jutsu->effects as $effect): ?>
+                                                                                <div class="jutsu_effect">
+                                                                                    <?php
+                                                                                    if ($effect->effect != "none") {
+                                                                                        echo in_array($effect->effect, ["substitution", "counter", "piercing", "recoil"])
+                                                                                            ? System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%)"
+                                                                                            : (($effect->effect == "none" && $jutsu->use_type == Jutsu::USE_TYPE_BARRIER)
+                                                                                                ? "Barrier"
+                                                                                                : System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
+                                                                                                    ? $effect->effect_length . " turn)"
+                                                                                                    : $effect->effect_length . " turns)"));
+                                                                                    }
+                                                                                    ?>
+                                                                                </div>
+                                                                    <?php endforeach; ?>
+                                                                </div>
                                                             </div>
-                                                    <?php endforeach; ?>
-                                                </div>
-                                            </div>
-                                            <?php $c3_count++; ?>
-                                <?php endforeach; ?>
+                                                            <?php $c3_count++; ?>
+                                            <?php endforeach; ?>
+                                        </div>
+                            <?php endif; ?>
                     <?php endif; ?>
-                <?php endif; ?>
-                </div>
                 <?php if (!$battle->isPreparationPhase() || ($show_submit_button)): ?>
                     <form action='<?= $self_link ?>' method='post'>
                         <input type='hidden' id='hand_seal_input' name='hand_seals' value='<?= $prefill_hand_seals ?>' />

--- a/templates/battle/battle_interface.php
+++ b/templates/battle/battle_interface.php
@@ -216,7 +216,12 @@ if($battle->battle_text) {
 
 <div class='submenu'>
     <ul class='submenu'>
-        <li style='width:100%;'><a href='<?= $refresh_link ?>'>Refresh Battle</a></li>
+        <?php if ($battleManager->spectate): ?>
+            <li style='width:100%;'><a href='<?= $refresh_link ?>'>Refresh Battle</a></li>
+        <?php else: ?>
+            <li style='width:49%;'><a href='<?= $refresh_link ?>'>Refresh Battle</a></li>
+            <li style='width:49%;'><a href='#actionSelect'>Action Select</a></li>
+        <?php endif; ?>
     </ul>
 </div>
 <div class='submenuMargin'></div>
@@ -332,7 +337,7 @@ if($battle->battle_text) {
 
     <!--// Trigger win action or display action prompt-->
     <?php if(!$battle->isComplete() && !$battleManager->spectate): ?>
-        <tr><th colspan='2'>Select Action</th></tr>
+        <tr><th id="actionSelect" colspan='2'>Select Action</th></tr>
 
         <?php if(!$battleManager->playerActionSubmitted()): ?>
             <?php require 'templates/battle/action_prompt.php'; ?>


### PR DESCRIPTION
- new button at top (same bar as refresh battle) jumps you straight to the jutsu select
- double clicking a jutsu uses the jutsu
- fixed weirdness with jutsu text overflowing
- clicking taijutsu adds the overlay thing to the hand seal rather than making the page jump up/down
- hand seal overlay now uses the same color as the container rather than blinding white

![image](https://github.com/elementum-games/shinobi-chronicles/assets/129538454/a62cc816-a9af-443f-9553-dd62f75fd62f)