### PR TITLE
Fix for new users to add BL data to table

### DIFF
--- a/classes/user/Blacklist.php
+++ b/classes/user/Blacklist.php
@@ -145,4 +145,11 @@ class Blacklist {
             $this->system->db->query("INSERT INTO `blacklist` (`user_id`, `blocked_ids`) VALUES ('$this->user_id', '$this->encodedBlacklist')");
         }
     }
+
+    public static function fromDb(System $system, int $user_id): Blacklist {
+        return new Blacklist(
+            system: $system,
+            user_id: $user_id
+        );
+    }
 }

--- a/classes/user/Blacklist.php
+++ b/classes/user/Blacklist.php
@@ -28,7 +28,7 @@ class Blacklist {
         }
         else {
             $this->blacklist = array();
-            $this->setEncodedBlacklist();
+            $this->createBlacklist();
         }
     }
 
@@ -132,7 +132,17 @@ class Blacklist {
     }
 
     // Update blacklist
-    public function updateData() {
+    public function updateData(): void {
         $this->system->db->query("UPDATE `blacklist` SET `blocked_ids`='$this->encodedBlacklist' WHERE `user_id` = $this->user_id LIMIT 1");
+    }
+
+    // Create blacklist
+    public function createBlacklist(): void {
+        // Redundancy check
+        $this->system->db->query("SELECT * FROM `blacklist` WHERE `user_id` = $this->user_id LIMIT 1");
+        if(!$this->system->db->last_num_rows) {
+            $this->encodedBlacklist = json_encode(array());
+            $this->system->db->query("INSERT INTO `blacklist` (`user_id`, `blocked_ids`) VALUES ('$this->user_id', '$this->encodedBlacklist')");
+        }
     }
 }


### PR DESCRIPTION
Added method to add blacklist data to table for new users
A blocked user mentioning/quoting you in chat no longer sends notifications
Quotes that are deleted, or blocked by viewing user, are now just stripped from the chat post (i.e. no longer displays "_(removed)_")