### PR TITLE
100% pre-heal

### DIFF
--- a/classes/battle/Battle.php
+++ b/classes/battle/Battle.php
@@ -18,7 +18,7 @@ class Battle {
     const MAX_TURN_LENGTH = 40;
     const PREP_LENGTH = 20;
 
-    const MAX_PRE_FIGHT_HEAL_PERCENT = 85;
+    const MAX_PRE_FIGHT_HEAL_PERCENT = 100;
 
     const TEAM1 = 'T1';
     const TEAM2 = 'T2';

--- a/classes/travel/Travel.php
+++ b/classes/travel/Travel.php
@@ -57,6 +57,9 @@ class Travel {
     }
 
     public static function checkAIDelay(int $last_ai_ms): int {
+        if (self::TRAVEL_DELAY_AI == 0) {
+            return 0;
+        }
         $diff = System::currentTimeMs() - $last_ai_ms;
         return self::TRAVEL_DELAY_AI - $diff;
     }


### PR DESCRIPTION
With the state of alt-sniping, war mechanics, and the ability to use healing items immediately after battle, pre-heal 100% creates an even playing field. Especially considering battles are generally evenly matched now rather than before where you would need lower pre-heal just to be evenly matched against your counter.

Personal suggestion: pre-heal that drains pools to use versus consumables so you still feel like you're making progress when attacking someone who is weakened, even if that battle doesn't result in a win.