### PR TITLE
Only select 'next friday' on days that aren't Friday

### DIFF
--- a/classes/System.php
+++ b/classes/System.php
@@ -218,7 +218,12 @@ class System {
 
         // New Server Time
         $this->SERVER_TIME = new DateTimeImmutable(datetime: "now", timezone: new DateTimeZone(self::SERVER_TIME_ZONE));
-        $this->REPUTATION_RESET = $this->SERVER_TIME->modify(self::REPUTATION_RESET_DAY);
+		$this->REPUTATION_RESET = $this->SERVER_TIME; // Piggyback server time
+    	if($this->SERVER_TIME->format('D') != 'Fri') {
+			// Set day to Friday
+			$this->REPUTATION_RESET = $this->SERVER_TIME->modify(self::REPUTATION_RESET_DAY);
+		}
+		// Push time to 2000 ET
         $this->REPUTATION_RESET = $this->REPUTATION_RESET->setTime(hour: self::REPUTATION_RESET_HOUR, minute: self::REPUTATION_RESET_MINUTE);
         // Old Server Time
         $this->timezoneOffset = date('Z');


### PR DESCRIPTION
Final fix for reputation reset timer, this fixes the issue where the timer would show that reputation reset on Fridays (server time) prior to 0100GMT.