### PR TITLE
Handle Travel Exceptions

### DIFF
--- a/classes/travel/TravelManager.php
+++ b/classes/travel/TravelManager.php
@@ -147,25 +147,29 @@ class TravelManager {
     public function movePlayer($direction): bool {
         $new_coords = Travel::getNewMovementValues($direction, $this->user->location);
         $ignore_coord_restrictions = $this->user->isHeadAdmin();
+        try {
+            if (!$this->checkRestrictions()) {
+                throw new InvalidMovementException('Unable to move!');
+            }
 
-        if (!$this->checkRestrictions()) {
-            throw new InvalidMovementException('Unable to move!');
-        }
+            // check if the coords exceed the map dimensions
+            if (($new_coords->x > $this->map_data['end_x']
+                || $new_coords->y > $this->map_data['end_y']
+                || $new_coords->x < 1
+                || $new_coords->y < 1)
+                && !$ignore_coord_restrictions) {
+                throw new InvalidMovementException('You cannot move past this point!');
+            }
 
-        // check if the coords exceed the map dimensions
-        if (($new_coords->x > $this->map_data['end_x']
-            || $new_coords->y > $this->map_data['end_y']
-            || $new_coords->x < 1
-            || $new_coords->y < 1)
-            && !$ignore_coord_restrictions) {
-            throw new InvalidMovementException('You cannot move past this point!');
-        }
-
-        // check if the user is trying to move to a village that is not theirs
-        if (TravelManager::locationIsInVillage($this->system, $new_coords)
-            && !$new_coords->equals($this->user->village_location)
-            && !$ignore_coord_restrictions) {
-            throw new InvalidMovementException('You cannot enter another village!');
+            // check if the user is trying to move to a village that is not theirs
+            if (TravelManager::locationIsInVillage($this->system, $new_coords)
+                && !$new_coords->equals($this->user->village_location)
+                && !$ignore_coord_restrictions) {
+                throw new InvalidMovementException('You cannot enter another village!');
+            }
+        } catch (InvalidMovementException $e) {
+            $this->setTravelMessage($e->getMessage());
+            return false;
         }
 
         // check if the user is entering their own village or out of it
@@ -194,23 +198,29 @@ class TravelManager {
 
         // portal data
         $portal_data = Travel::getPortalData($this->system, $portal_id);
-        if (empty($portal_data)) {
-            throw new InvalidMovementException('You cannot enter here!');
-        }
-        if (!$this->checkRestrictions()) {
-            throw new InvalidMovementException('Unable to move!');
-        }
 
-        // check if the player is at the correct entrance
-        if (!$this->user->location->equals(new TravelCoords($portal_data['entrance_x'], $portal_data['entrance_y'], $portal_data['from_id']))
-            && !$ignore_travel_restrictions) {
-            throw new InvalidMovementException('You cannot enter here!');
-        }
+        try {
+            if (empty($portal_data)) {
+                throw new InvalidMovementException('You cannot enter here!');
+            }
+            if (!$this->checkRestrictions()) {
+                throw new InvalidMovementException('Unable to move!');
+            }
 
-        // check if the player is in a faction that allows this portal
-        $portal_whitelist = array_map('trim', explode(',', $portal_data['whitelist']));
-        if (!in_array($this->user->village->name, $portal_whitelist) && !$ignore_travel_restrictions) {
-            throw new InvalidMovementException('You are unable to enter here!');
+            // check if the player is at the correct entrance
+            if (!$this->user->location->equals(new TravelCoords($portal_data['entrance_x'], $portal_data['entrance_y'], $portal_data['from_id']))
+                && !$ignore_travel_restrictions) {
+                throw new InvalidMovementException('You cannot enter here!');
+            }
+
+            // check if the player is in a faction that allows this portal
+            $portal_whitelist = array_map('trim', explode(',', $portal_data['whitelist']));
+            if (!in_array($this->user->village->name, $portal_whitelist) && !$ignore_travel_restrictions) {
+                throw new InvalidMovementException('You are unable to enter here!');
+            }
+        } catch (InvalidMovementException $e) {
+            $this->setTravelMessage($e->getMessage());
+            return false;
         }
 
         // update the player data
@@ -607,68 +617,73 @@ class TravelManager {
         $user = User::loadFromId($this->system, $target_user_id);
         $user->loadData(User::UPDATE_NOTHING, true);
 
-        // check if the location forbids pvp
-        if ($this->user->current_location->location_id && $this->user->current_location->pvp_allowed == 0) {
-            throw new RuntimeException("You cannot fight at this location!");
-        }
+        try {
+            // check if the location forbids pvp
+            if ($this->user->current_location->location_id && $this->user->current_location->pvp_allowed == 0) {
+                throw new RuntimeException("You cannot fight at this location!");
+            }
 
-        if ($user->village->name == $this->user->village->name) {
-            throw new RuntimeException("You cannot attack people from your own village!");
-        }
+            if ($user->village->name == $this->user->village->name) {
+                throw new RuntimeException("You cannot attack people from your own village!");
+            }
 
-        if ($user->rank_num < 3) {
-            throw new RuntimeException("You cannot attack people below Chuunin rank!");
-        }
-        if ($this->user->rank_num < 3) {
-            throw new RuntimeException("You cannot attack people Chuunin rank and higher!");
-        }
+            if ($user->rank_num < 3) {
+                throw new RuntimeException("You cannot attack people below Chuunin rank!");
+            }
+            if ($this->user->rank_num < 3) {
+                throw new RuntimeException("You cannot attack people Chuunin rank and higher!");
+            }
 
-        // bypass rank restruction if target taking war action or carrying loot
-        if ($user->rank_num !== $this->user->rank_num) {
-            if ($user->operation == 0) {
-                $loot_count = 0;
-                $loot_result = $this->system->db->query("SELECT COUNT(*) as `count` FROM `loot` WHERE `user_id` = {$user->user_id} AND `claimed_village_id` IS NULL AND `battle_id` IS NULL LIMIT 1");
-                if ($this->system->db->last_num_rows > 0) {
-                    $loot_result = $this->system->db->fetch($loot_result);
-                    $loot_count = $loot_result['count'];
-                }
-                if ($loot_count == 0) {
-                    throw new RuntimeException("You can only attack people of the same rank!");
+            // bypass rank restruction if target taking war action or carrying loot
+            if ($user->rank_num !== $this->user->rank_num) {
+                if ($user->operation == 0) {
+                    $loot_count = 0;
+                    $loot_result = $this->system->db->query("SELECT COUNT(*) as `count` FROM `loot` WHERE `user_id` = {$user->user_id} AND `claimed_village_id` IS NULL AND `battle_id` IS NULL LIMIT 1");
+                    if ($this->system->db->last_num_rows > 0) {
+                        $loot_result = $this->system->db->fetch($loot_result);
+                        $loot_count = $loot_result['count'];
+                    }
+                    if ($loot_count == 0) {
+                        throw new RuntimeException("You can only attack people of the same rank!");
+                    }
                 }
             }
-        }
 
-        if (!$user->location->equals($this->user->location)) {
-            throw new RuntimeException("Target is not at your location!");
-        }
-        if ($user->battle_id) {
-            throw new RuntimeException("Target is in battle!");
-        }
-        if ($user->last_active < time() - 120) {
-            throw new RuntimeException("Target is inactive/offline!");
-        }
-        /*
-        if ($this->user->pvp_immunity_ms > System::currentTimeMs()) {
-            throw new RuntimeException("You were defeated within the last " . User::PVP_IMMUNITY_SECONDS . "s, please wait " .
-                ceil(($this->user->pvp_immunity_ms - System::currentTimeMs()) / 1000) . " more seconds.");
-        }*/
-        if ($this->user->last_death_ms > System::currentTimeMs() - (User::PVP_IMMUNITY_SECONDS * 1000)) {
-            throw new RuntimeException("You died within the last " . User::PVP_IMMUNITY_SECONDS . "s, please wait " .
-                ceil((($this->user->last_death_ms + (User::PVP_IMMUNITY_SECONDS * 1000)) - System::currentTimeMs()) / 1000) . " more seconds.");
-        }
-        if ($user->pvp_immunity_ms > System::currentTimeMs()) {
-            throw new RuntimeException("Target has died recently and immune to being attacked.");
-        }
-        /*
-        if ($user->last_death_ms > System::currentTimeMs() - (60 * 1000)) {
-            throw new RuntimeException("Target has died within the last minute, please wait " .
-                ceil((($user->last_death_ms + (60 * 1000)) - System::currentTimeMs()) / 1000) . " more seconds.");
-        }*/
-        if ($this->user->operation > 0) {
-            throw new RuntimeException("You are currently in an operation!");
-        }
-        if ($this->dbFetchIsProtectedByAlly($user) && $this->user->rank_num >= 4) {
-            throw new RuntimeException("Target is protected by a higher rank ally! Attack them first.");
+            if (!$user->location->equals($this->user->location)) {
+                throw new RuntimeException("Target is not at your location!");
+            }
+            if ($user->battle_id) {
+                throw new RuntimeException("Target is in battle!");
+            }
+            if ($user->last_active < time() - 120) {
+                throw new RuntimeException("Target is inactive/offline!");
+            }
+            /*
+            if ($this->user->pvp_immunity_ms > System::currentTimeMs()) {
+                throw new RuntimeException("You were defeated within the last " . User::PVP_IMMUNITY_SECONDS . "s, please wait " .
+                    ceil(($this->user->pvp_immunity_ms - System::currentTimeMs()) / 1000) . " more seconds.");
+            }*/
+            if ($this->user->last_death_ms > System::currentTimeMs() - (User::PVP_IMMUNITY_SECONDS * 1000)) {
+                throw new RuntimeException("You died within the last " . User::PVP_IMMUNITY_SECONDS . "s, please wait " .
+                    ceil((($this->user->last_death_ms + (User::PVP_IMMUNITY_SECONDS * 1000)) - System::currentTimeMs()) / 1000) . " more seconds.");
+            }
+            if ($user->pvp_immunity_ms > System::currentTimeMs()) {
+                throw new RuntimeException("Target has died recently and immune to being attacked.");
+                }
+                /*
+                if ($user->last_death_ms > System::currentTimeMs() - (60 * 1000)) {
+                    throw new RuntimeException("Target has died within the last minute, please wait " .
+                        ceil((($user->last_death_ms + (60 * 1000)) - System::currentTimeMs()) / 1000) . " more seconds.");
+                }*/
+            if ($this->user->operation > 0) {
+                throw new RuntimeException("You are currently in an operation!");
+            }
+            if ($this->dbFetchIsProtectedByAlly($user) && $this->user->rank_num >= 4) {
+                throw new RuntimeException("Target is protected by a higher rank ally! Attack them first.");
+            }
+        } catch (RuntimeException $e) {
+            $this->setTravelMessage($e->getMessage());
+            return false;
         }
 
         if ($this->system->USE_NEW_BATTLES) {


### PR DESCRIPTION
Use existing travel message logic to display "normal" exceptions rather than flooding the error log with uncaught exceptions.

![image](https://github.com/elementum-games/shinobi-chronicles/assets/129538454/8c8fbd50-49ab-4739-8fd5-6e4a0b117929)
