### PR TITLE
Bloodline Jutsu Display

### DIFF
--- a/classes/Bloodline.php
+++ b/classes/Bloodline.php
@@ -141,6 +141,8 @@ class Bloodline {
                         $bloodline->jutsu[$id]->setLevel($uj['level'], $uj['exp']);
                     }
                 }
+
+                ksort($bloodline->jutsu);
             }
             else {
                 $bloodline->jutsu = array();

--- a/templates/battle/action_prompt.php
+++ b/templates/battle/action_prompt.php
@@ -475,10 +475,10 @@ $prefill_item_id = $_POST['item_id'] ?? '';
                                             <?php
                                             if ($effect->effect != "none") {
                                                 echo in_array($effect->effect, ["substitution", "counter", "piercing", "recoil"])
-                                                    ? System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%)"
+                                                    ? System::unSlug($effect->effect) . " (" . round($effect->display_effect_amount, 0) . "%)"
                                                     : (($effect->effect == "none" && $attack->use_type == Jutsu::USE_TYPE_BARRIER)
                                                         ? "Barrier"
-                                                        : System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
+                                                        : System::unSlug($effect->effect) . " (" . round($effect->display_effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
                                                             ? $effect->effect_length . " turn)"
                                                             : $effect->effect_length . " turns)"));
                                             }
@@ -522,10 +522,10 @@ $prefill_item_id = $_POST['item_id'] ?? '';
                                                     <?php
                                                         if ($effect->effect != "none") {
                                                             echo in_array($effect->effect, ["substitution", "counter", "piercing", "recoil"])
-                                                                ? System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%)"
+                                                                ? System::unSlug($effect->effect) . " (" . round($effect->display_effect_amount, 0) . "%)"
                                                                 : (($effect->effect == "none" && $player_jutsu->use_type == Jutsu::USE_TYPE_BARRIER)
                                                                     ? "Barrier"
-                                                                    : System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
+                                                                    : System::unSlug($effect->effect) . " (" . round($effect->display_effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
                                                                         ? $effect->effect_length . " turn)"
                                                                         : $effect->effect_length . " turns)"));
                                                         }
@@ -569,10 +569,10 @@ $prefill_item_id = $_POST['item_id'] ?? '';
                                                                                     <?php
                                                                                     if ($effect->effect != "none") {
                                                                                         echo in_array($effect->effect, ["substitution", "counter", "piercing", "recoil"])
-                                                                                            ? System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%)"
+                                                                                            ? System::unSlug($effect->effect) . " (" . round($effect->display_effect_amount, 0) . "%)"
                                                                                             : (($effect->effect == "none" && $jutsu->use_type == Jutsu::USE_TYPE_BARRIER)
                                                                                                 ? "Barrier"
-                                                                                                : System::unSlug($effect->effect) . " (" . round($effect->effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
+                                                                                                : System::unSlug($effect->effect) . " (" . round($effect->display_effect_amount, 0) . "%" . ", " . ($effect->effect_length == 1
                                                                                                     ? $effect->effect_length . " turn)"
                                                                                                     : $effect->effect_length . " turns)"));
                                                                                     }


### PR DESCRIPTION
- Display bloodline jutsu in rank order
- Fix issue where bloodline jutsu would show the actual power of the residual damage after use instead of the % (e.g. 478437 instead of 25%)