### PR TITLE
Battle Rounds

### DIFF
--- a/api/battle.php
+++ b/api/battle.php
@@ -55,10 +55,11 @@ function handleBattleRequest(System $system, User $player): void {
         try {
             $battle_id = $system->db->clean($_GET['check_turn']);
             $response = new APIResponse();
-            $battle_result = $system->db->query("SELECT `turn_count`, `turn_time`, `player1_time`, `player2_time` FROM `battles` WHERE `battle_id`='{$battle_id}' LIMIT 1");
+            $battle_result = $system->db->query("SELECT `turn_count`, `turn_time`, `player1_time`, `player2_time`, `round_count` FROM `battles` WHERE `battle_id`='{$battle_id}' LIMIT 1");
             if ($system->db->last_num_rows) {
                 $battle_result = $system->db->fetch($battle_result);
                 $response->data['turn_count'] = $battle_result['turn_count'];
+                $response->data['round_count'] = $battle_result['round_count'];
                 $response->data['player1_time'] = Battle::calcTimeRemaining($battle_result['turn_time'], $battle_result['player1_time']);
                 $response->data['player2_time'] = Battle::calcTimeRemaining($battle_result['turn_time'], $battle_result['player2_time']);
                 API::exitWithData(

--- a/classes/battle/Battle.php
+++ b/classes/battle/Battle.php
@@ -81,6 +81,11 @@ class Battle {
 
     public string $battle_background_link;
 
+    public int $rounds = 1;
+    public int $current_round = 1;
+    public int $team1_wins;
+    public int $team2_wins;
+
     /**
      * @param System  $system
      * @param Fighter $player1
@@ -90,7 +95,7 @@ class Battle {
      * @throws RuntimeException
      */
     public static function start(
-        System $system, Fighter $player1, Fighter $player2, int $battle_type, ?int $patrol_id = null, string $battle_background_link = ''
+        System $system, Fighter $player1, Fighter $player2, int $battle_type, ?int $patrol_id = null, string $battle_background_link = '', int $rounds = 1
     ) {
         $json_empty_array = '[]';
 
@@ -135,7 +140,8 @@ class Battle {
                 `fighter_jutsu_used` = '" . $json_empty_array . "',
                 `is_retreat` = '" . (int)false . "',
                 `patrol_id` = " . (!empty($patrol_id) ? $patrol_id : "NULL") . ",
-                `battle_background_link` = '{$battle_background_link}'
+                `battle_background_link` = '{$battle_background_link}',
+                `rounds` = {$rounds}
         ");
         $battle_id = $system->db->last_insert_id;
 
@@ -261,6 +267,11 @@ class Battle {
         $this->player2_last_damage_taken = $battle['player2_last_damage_taken'];
 
         $this->battle_background_link = empty($battle['battle_background_link']) ? '' : $battle['battle_background_link'];
+
+        $this->rounds = $battle['rounds'];
+        $this->current_round = $battle['current_round'];
+        $this->team1_wins = $battle['team1_wins'];
+        $this->team2_wins = $battle['team2_wins'];
     }
 
     /**
@@ -386,7 +397,7 @@ class Battle {
                 }
             }
         }
-      
+
         if (!$this->player2 instanceof NPC) {
             foreach ($this->player2->jutsu as $jutsu) {
                 if ($jutsu->rank == 1)
@@ -526,7 +537,11 @@ class Battle {
             `fighter_jutsu_used` = '" . json_encode($this->fighter_jutsu_used) . "',
 
             `player1_last_damage_taken` = {$this->player1->last_damage_taken},
-            `player2_last_damage_taken` = {$this->player2->last_damage_taken}
+            `player2_last_damage_taken` = {$this->player2->last_damage_taken},
+
+            `current_round` = {$this->current_round},
+            `team1_wins` = {$this->team1_wins},
+            `team2_wins` = {$this->team2_wins}
             WHERE `battle_id` = '{$this->battle_id}' LIMIT 1"
         );
 

--- a/classes/battle/Battle.php
+++ b/classes/battle/Battle.php
@@ -29,7 +29,7 @@ class Battle {
     const MIN_DEBUFF_RATIO = 0.1;
     const MAX_DIFFUSE_PERCENT = 0.75;
 
-    const REPUTATION_DAMAGE_RESISTANCE_BOOST = 15;
+    const REPUTATION_DAMAGE_RESISTANCE_BOOST = 5;
 
     private System $system;
 
@@ -82,7 +82,7 @@ class Battle {
     public string $battle_background_link;
 
     public int $rounds = 1;
-    public int $current_round = 1;
+    public int $round_count = 0;
     public int $team1_wins;
     public int $team2_wins;
 
@@ -269,7 +269,7 @@ class Battle {
         $this->battle_background_link = empty($battle['battle_background_link']) ? '' : $battle['battle_background_link'];
 
         $this->rounds = $battle['rounds'];
-        $this->current_round = $battle['current_round'];
+        $this->round_count = $battle['round_count'];
         $this->team1_wins = $battle['team1_wins'];
         $this->team2_wins = $battle['team2_wins'];
     }
@@ -539,7 +539,7 @@ class Battle {
             `player1_last_damage_taken` = {$this->player1->last_damage_taken},
             `player2_last_damage_taken` = {$this->player2->last_damage_taken},
 
-            `current_round` = {$this->current_round},
+            `round_count` = {$this->round_count},
             `team1_wins` = {$this->team1_wins},
             `team2_wins` = {$this->team2_wins}
             WHERE `battle_id` = '{$this->battle_id}' LIMIT 1"

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -666,23 +666,25 @@ class BattleManager {
             return Battle::DRAW;
         }
         // if team1 majority of wins (total rounds)
-        if ($this->battle->team1_wins > floor($this->battle->rounds / 2) || ($this->battle->current_round > $this->battle->rounds && $this->battle->team1_wins > $this->battle->team2_wins)) {
-             return Battle::TEAM1;
+        if ($this->battle->team1_wins > floor($this->battle->rounds / 2) || ($this->battle->round_count >= $this->battle->rounds && $this->battle->team1_wins > $this->battle->team2_wins)) {
+            return Battle::TEAM1;
         }
         // if team2 majority of wins (total rounds)
-        if ($this->battle->team2_wins > floor($this->battle->rounds / 2) || ($this->battle->current_round > $this->battle->rounds && $this->battle->team2_wins > $this->battle->team1_wins)) {
+        if ($this->battle->team2_wins > floor($this->battle->rounds / 2) || ($this->battle->round_count >= $this->battle->rounds && $this->battle->team2_wins > $this->battle->team1_wins)) {
             return Battle::TEAM2;
         }
         // if more rounds to go
-        if ($this->battle->current_round < $this->battle->rounds) {
-            $this->battle->current_round++;
+        if ($this->battle->round_count < $this->battle->rounds) {
+            $this->battle->round_count++;
             $this->battle->player1->health = $this->battle->player1->max_health;
+            $this->battle->fighter_health[$this->battle->player1->combat_id] = $this->battle->player1->health;
             $this->battle->player1_last_damage_taken = 0;
             $this->battle->player2->health = $this->battle->player2->max_health;
+            $this->battle->fighter_health[$this->battle->player2->combat_id] = $this->battle->player2->health;
             $this->battle->player2_last_damage_taken = 0;
             $this->effects->active_effects = [];
             $this->battle->jutsu_cooldowns = [];
-            $this->battle->turn_count = 1;
+            $this->battle->turn_count = 0;
             $this->battle->turn_time = time();
             $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
             $this->battle->player2_time = Battle::MAX_TURN_LENGTH;
@@ -690,14 +692,16 @@ class BattleManager {
         }
         // if rounds completed but no winner
         if ($this->battle->team1_wins == $this->battle->team2_wins) {
-            $this->battle->current_round++;
+            $this->battle->round_count++;
             $this->battle->player1->health = $this->battle->player1->max_health;
+            $this->battle->fighter_health[$this->battle->player1->combat_id] = $this->battle->player1->health;
             $this->battle->player1_last_damage_taken = 0;
             $this->battle->player2->health = $this->battle->player2->max_health;
+            $this->battle->fighter_health[$this->battle->player2->combat_id] = $this->battle->player2->health;
             $this->battle->player2_last_damage_taken = 0;
             $this->effects->active_effects = [];
             $this->battle->jutsu_cooldowns = [];
-            $this->battle->turn_count = 1;
+            $this->battle->turn_count = 0;
             $this->battle->turn_time = time();
             $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
             $this->battle->player2_time = Battle::MAX_TURN_LENGTH;

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -676,39 +676,33 @@ class BattleManager {
         // if more rounds to go
         if ($this->battle->round_count < $this->battle->rounds) {
             $this->battle->round_count++;
-            $this->battle->player1->health = $this->battle->player1->max_health;
-            $this->battle->fighter_health[$this->battle->player1->combat_id] = $this->battle->player1->health;
-            $this->battle->player1_last_damage_taken = 0;
-            $this->battle->player2->health = $this->battle->player2->max_health;
-            $this->battle->fighter_health[$this->battle->player2->combat_id] = $this->battle->player2->health;
-            $this->battle->player2_last_damage_taken = 0;
-            $this->effects->active_effects = [];
-            $this->battle->jutsu_cooldowns = [];
-            $this->battle->turn_count = 0;
-            $this->battle->turn_time = time();
-            $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
-            $this->battle->player2_time = Battle::MAX_TURN_LENGTH;
+            $this->resetBattle();
             return '';
         }
         // if rounds completed but no winner
         if ($this->battle->team1_wins == $this->battle->team2_wins) {
             $this->battle->round_count++;
-            $this->battle->player1->health = $this->battle->player1->max_health;
-            $this->battle->fighter_health[$this->battle->player1->combat_id] = $this->battle->player1->health;
-            $this->battle->player1_last_damage_taken = 0;
-            $this->battle->player2->health = $this->battle->player2->max_health;
-            $this->battle->fighter_health[$this->battle->player2->combat_id] = $this->battle->player2->health;
-            $this->battle->player2_last_damage_taken = 0;
-            $this->effects->active_effects = [];
-            $this->battle->jutsu_cooldowns = [];
-            $this->battle->turn_count = 0;
-            $this->battle->turn_time = time();
-            $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
-            $this->battle->player2_time = Battle::MAX_TURN_LENGTH;
+            $this->resetBattle();
             return '';
         }
         // return no winner as failsafe
         return '';
+    }
+
+    #[Trace]
+    private function resetBattle() {
+        $this->battle->player1->health = $this->battle->player1->max_health;
+        $this->battle->fighter_health[$this->battle->player1->combat_id] = $this->battle->player1->health;
+        $this->battle->player1_last_damage_taken = 0;
+        $this->battle->player2->health = $this->battle->player2->max_health;
+        $this->battle->fighter_health[$this->battle->player2->combat_id] = $this->battle->player2->health;
+        $this->battle->player2_last_damage_taken = 0;
+        $this->effects->active_effects = [];
+        $this->battle->jutsu_cooldowns = [];
+        $this->battle->turn_count = 0;
+        $this->battle->turn_time = time();
+        $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
+        $this->battle->player2_time = Battle::MAX_TURN_LENGTH;
     }
 
     /**

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -635,13 +635,13 @@ class BattleManager {
         }
 
         if($this->battle->player1->health > 0 && $this->battle->player2->health <= 0) {
-            $this->battle->winner = Battle::TEAM1;
+            $this->battle->winner = $this->handleRoundCompletion(Battle::TEAM1);
         }
         else if($this->battle->player2->health > 0 && $this->battle->player1->health <= 0) {
-            $this->battle->winner = Battle::TEAM2;
+            $this->battle->winner = $this->handleRoundCompletion(Battle::TEAM2);
         }
         else if($this->battle->player1->health <= 0 && $this->battle->player2->health <= 0) {
-            $this->battle->winner = Battle::DRAW;
+            $this->battle->winner = $this->handleRoundCompletion(Battle::DRAW);
         }
 
         if($this->battle->winner && !$this->spectate) {
@@ -649,6 +649,62 @@ class BattleManager {
         }
 
         return $this->battle->winner;
+    }
+
+    #[Trace]
+    private function handleRoundCompletion(string $round_winner): string {
+        // if round winner is team1, increment wins
+        if ($round_winner == Battle::TEAM1) {
+            $this->battle->team1_wins++;
+        }
+        // if round winner is team2, increment wins
+        if ($round_winner == Battle::TEAM2) {
+            $this->battle->team2_wins++;
+        }
+        // if single-round battle and round is draw
+        if ($this->battle->rounds <= 1 && $round_winner == Battle::DRAW) {
+            return Battle::DRAW;
+        }
+        // if team1 majority of wins (total rounds)
+        if ($this->battle->team1_wins > floor($this->battle->rounds / 2) || ($this->battle->current_round > $this->battle->rounds && $this->battle->team1_wins > $this->battle->team2_wins)) {
+             return Battle::TEAM1;
+        }
+        // if team2 majority of wins (total rounds)
+        if ($this->battle->team2_wins > floor($this->battle->rounds / 2) || ($this->battle->current_round > $this->battle->rounds && $this->battle->team2_wins > $this->battle->team1_wins)) {
+            return Battle::TEAM2;
+        }
+        // if more rounds to go
+        if ($this->battle->current_round < $this->battle->rounds) {
+            $this->battle->current_round++;
+            $this->battle->player1->health = $this->battle->player1->max_health;
+            $this->battle->player1_last_damage_taken = 0;
+            $this->battle->player2->health = $this->battle->player2->max_health;
+            $this->battle->player2_last_damage_taken = 0;
+            $this->effects->active_effects = [];
+            $this->battle->jutsu_cooldowns = [];
+            $this->battle->turn_count = 1;
+            $this->battle->turn_time = time();
+            $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
+            $this->battle->player2_time = Battle::MAX_TURN_LENGTH;
+            return '';
+        }
+        // if rounds completed but no winner
+        if ($this->battle->team1_wins == $this->battle->team2_wins) {
+            $this->battle->current_round++;
+            $this->battle->player1->health = $this->battle->player1->max_health;
+            $this->battle->player1_last_damage_taken = 0;
+            $this->battle->player2->health = $this->battle->player2->max_health;
+            $this->battle->player2_last_damage_taken = 0;
+            $this->effects->active_effects = [];
+            $this->battle->jutsu_cooldowns = [];
+            $this->battle->turn_count = 1;
+            $this->battle->turn_time = time();
+            $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
+            $this->battle->player2_time = Battle::MAX_TURN_LENGTH;
+            return '';
+        }
+        // return no winner as failsafe
+        return '';
     }
 
     /**

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -692,10 +692,10 @@ class BattleManager {
     #[Trace]
     private function resetBattle() {
         $this->battle->player1->health = $this->battle->player1->max_health;
-        $this->battle->fighter_health[$this->battle->player1->combat_id] = $this->battle->player1->health;
+        $this->battle->fighter_health[$this->battle->player1->combat_id] = $this->battle->player1->max_health;
         $this->battle->player1_last_damage_taken = 0;
         $this->battle->player2->health = $this->battle->player2->max_health;
-        $this->battle->fighter_health[$this->battle->player2->combat_id] = $this->battle->player2->health;
+        $this->battle->fighter_health[$this->battle->player2->combat_id] = $this->battle->player2->max_health;
         $this->battle->player2_last_damage_taken = 0;
         $this->effects->active_effects = [];
         $this->battle->jutsu_cooldowns = [];
@@ -703,6 +703,8 @@ class BattleManager {
         $this->battle->turn_time = time();
         $this->battle->player1_time = Battle::MAX_TURN_LENGTH;
         $this->battle->player2_time = Battle::MAX_TURN_LENGTH;
+        $this->battle->player1->updateData();
+        $this->battle->player2->updateData();
     }
 
     /**

--- a/classes/battle/BattleV2.php
+++ b/classes/battle/BattleV2.php
@@ -82,7 +82,7 @@ class BattleV2 {
     public string $battle_background_link;
 
     public int $rounds = 1;
-    public int $current_round = 1;
+    public int $round_count = 1;
     public int $team1_wins;
     public int $team2_wins;
 
@@ -241,7 +241,7 @@ class BattleV2 {
         $battle->battle_background_link = empty($battle_data['battle_background_link']) ? '' : $battle_data['battle_background_link'];
 
         $battle->rounds = $battle_data['rounds'];
-        $battle->current_round = $battle_data['current_round'];
+        $battle->round_count = $battle_data['round_count'];
         $battle->team1_wins = $battle_data['team1_wins'];
         $battle->team2_wins = $battle_data['team2_wins'];
 
@@ -382,7 +382,7 @@ class BattleV2 {
                 `jutsu_cooldowns` = '" . json_encode($this->jutsu_cooldowns) . "',
                 `fighter_jutsu_used` = '" . json_encode($this->fighter_jutsu_used) . "'
 
-                `current_round` = {$this->current_round},
+                `round_count` = {$this->round_count},
                 `team1_wins` = {$this->team1_wins},
                 `team2_wins` = {$this->team2_wins}
             WHERE `battle_id` = '{$this->battle_id}' LIMIT 1"

--- a/classes/battle/BattleV2.php
+++ b/classes/battle/BattleV2.php
@@ -81,6 +81,11 @@ class BattleV2 {
 
     public string $battle_background_link;
 
+    public int $rounds = 1;
+    public int $current_round = 1;
+    public int $team1_wins;
+    public int $team2_wins;
+
     /**
      * @param System   $system
      * @param Fighter  $player1
@@ -91,7 +96,7 @@ class BattleV2 {
      * @throws DatabaseDeadlockException
      */
     public static function start(
-        System $system, Fighter $player1, Fighter $player2, int $battle_type, ?int $patrol_id = null, string $battle_background_link = ''
+        System $system, Fighter $player1, Fighter $player2, int $battle_type, ?int $patrol_id = null, string $battle_background_link = '', int $rounds = 1
     ): int {
         $json_empty_array = '[]';
 
@@ -137,7 +142,8 @@ class BattleV2 {
                 `fighter_jutsu_used` = '" . $json_empty_array . "',
                 `is_retreat` = '" . (int) false . "',
                 `patrol_id` = " . (!empty($patrol_id) ? $patrol_id : "NULL") . ",
-                `battle_background_link` = '{$battle_background_link}'
+                `battle_background_link` = '{$battle_background_link}',
+                `rounds` = '{$rounds}'
         ");
         $battle_id = $system->db->last_insert_id;
 
@@ -231,6 +237,13 @@ class BattleV2 {
 
         $battle->current_turn_log = $current_turn_log;
         $battle->log[$battle->turn_count] = $battle->current_turn_log;
+
+        $battle->battle_background_link = empty($battle_data['battle_background_link']) ? '' : $battle_data['battle_background_link'];
+
+        $battle->rounds = $battle_data['rounds'];
+        $battle->current_round = $battle_data['current_round'];
+        $battle->team1_wins = $battle_data['team1_wins'];
+        $battle->team2_wins = $battle_data['team2_wins'];
 
         return $battle;
     }
@@ -368,6 +381,10 @@ class BattleV2 {
 
                 `jutsu_cooldowns` = '" . json_encode($this->jutsu_cooldowns) . "',
                 `fighter_jutsu_used` = '" . json_encode($this->fighter_jutsu_used) . "'
+
+                `current_round` = {$this->current_round},
+                `team1_wins` = {$this->team1_wins},
+                `team2_wins` = {$this->team2_wins}
             WHERE `battle_id` = '{$this->battle_id}' LIMIT 1"
         );
 

--- a/classes/village/VillageManager.php
+++ b/classes/village/VillageManager.php
@@ -901,9 +901,9 @@ class VillageManager {
                 $challenger->loadData(User::UPDATE_NOTHING);
             }
             if ($system->USE_NEW_BATTLES) {
-                $battle_id = BattleV2::start($system, $challenger, $seat_holder, Battle::TYPE_CHALLENGE);
+                $battle_id = BattleV2::start($system, $challenger, $seat_holder, Battle::TYPE_CHALLENGE, rounds: 3);
             } else {
-                $battle_id = Battle::start($system, $challenger, $seat_holder, Battle::TYPE_CHALLENGE);
+                $battle_id = Battle::start($system, $challenger, $seat_holder, Battle::TYPE_CHALLENGE, rounds: 3);
             }
             $system->db->query("UPDATE `challenge_requests` SET `battle_id` = {$battle_id} WHERE `request_id` = {$player->locked_challenge}");
             return;

--- a/db/migrations/20240108071157_battle_round_migration.php
+++ b/db/migrations/20240108071157_battle_round_migration.php
@@ -13,7 +13,7 @@ final class BattleRoundMigration extends AbstractMigration
         $this->execute("
             -- Alter table battles
             ALTER TABLE `battles` ADD `rounds` INT(11) NOT NULL DEFAULT '1';
-            ALTER TABLE `battles` ADD `current_round` INT(11) NOT NULL DEFAULT '1';
+            ALTER TABLE `battles` ADD `round_count` INT(11) NOT NULL DEFAULT '0';
             ALTER TABLE `battles` ADD `team1_wins` INT(11) NOT NULL DEFAULT '0';
             ALTER TABLE `battles` ADD `team2_wins` INT(11) NOT NULL DEFAULT '0';
         ");
@@ -27,7 +27,7 @@ final class BattleRoundMigration extends AbstractMigration
         $this->execute("
             -- Alter table battles
             ALTER TABLE `battles` DROP `rounds`;
-            ALTER TABLE `battles` DROP `current_round`;
+            ALTER TABLE `battles` DROP `round_count`;
             ALTER TABLE `battles` DROP `team1_wins`;
             ALTER TABLE `battles` DROP `team2_wins`;
         ");

--- a/db/migrations/20240108071157_battle_round_migration.php
+++ b/db/migrations/20240108071157_battle_round_migration.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+use Phinx\Migration\AbstractMigration;
+
+final class BattleRoundMigration extends AbstractMigration
+{
+    /**
+     * Migrate Up.
+     */
+    public function up(): void
+    {
+        $this->execute("
+            -- Alter table battles
+            ALTER TABLE `battles` ADD `rounds` INT(11) NOT NULL DEFAULT '1';
+            ALTER TABLE `battles` ADD `current_round` INT(11) NOT NULL DEFAULT '1';
+            ALTER TABLE `battles` ADD `team1_wins` INT(11) NOT NULL DEFAULT '0';
+            ALTER TABLE `battles` ADD `team2_wins` INT(11) NOT NULL DEFAULT '0';
+        ");
+    }
+
+    /**
+     * Migrate Down.
+     */
+    public function down(): void
+    {
+        $this->execute("
+            -- Alter table battles
+            ALTER TABLE `battles` DROP `rounds`;
+            ALTER TABLE `battles` DROP `current_round`;
+            ALTER TABLE `battles` DROP `team1_wins`;
+            ALTER TABLE `battles` DROP `team2_wins`;
+        ");
+    }
+}

--- a/templates/battle/battle_interface.php
+++ b/templates/battle/battle_interface.php
@@ -44,6 +44,7 @@ if($battle->battle_text) {
     let battle_id = <?= $battle->battle_id ?>;
     var apiUrl = `api/battle.php?check_turn=` + battle_id;
     let turn_count = <?= $battle->turn_count ?>;
+    let round_count = <?= $battle->round_count ?>;
     let prep_time_remaining = <?= $battle->prepTimeRemaining() ?>;
     let player1_submitted = <?= (int)isset($battle->fighter_actions[$battle->player1->combat_id]) ?>;
     let player2_submitted = <?= (int)isset($battle->fighter_actions[$battle->player2->combat_id]) ?>;
@@ -66,7 +67,7 @@ if($battle->battle_text) {
         fetch(apiUrl)
             .then(response => response.json())
             .then(data => {
-                if (data.data != undefined && data.data.turn_count > turn_count) {
+                if (data.data != undefined && (data.data.turn_count > turn_count || data.data.round_count > round_count)) {
                     updateContent();
                 } else {
                     player1_time = data.data.player1_time;

--- a/templates/battle/battle_interface.php
+++ b/templates/battle/battle_interface.php
@@ -245,16 +245,26 @@ if($battle->battle_text) {
 
 <?php $system->printMessage(); ?>
 <table id="battle_details" class='table'>
+    <?php if ($battle->rounds > 1): ?>
+    <tr><th colspan="2">Round <?= $battle->round_count + 1 ?> of <?= $battle->rounds ?> | Turn <?= $battle->winner ? $battle->turn_count : $battle->turn_count + 1 ?></th></tr>
+    <?php else: ?>
     <tr><th colspan="2">Turn <?= $battle->winner ? $battle->turn_count : $battle->turn_count + 1 ?></th></tr>
+    <?php endif; ?>
     <tr>
         <th id='bi_th_user' style='width:50%;'>
             <a href='<?= $system->router->links['members'] ?>&user=<?= $player->getName() ?>' style='text-decoration:none'><?= $player->getName() ?></a>
+            <?php if ($battle->rounds > 1): ?>
+                - <?= $battle->team1_wins ?> wins
+            <?php endif; ?>
         </th>
         <th id='bi_th_opponent' style='width:50%;'>
             <?php if($opponent instanceof NPC): ?>
                 <?= $opponent->getName() ?>
             <?php else: ?>
                 <a href='<?= $system->router->links['members'] ?>&user=<?= $opponent->getName() ?>' style='text-decoration:none'><?= $opponent->getName() ?></a>
+            <?php endif; ?>
+            <?php if ($battle->rounds > 1): ?>
+            - <?= $battle->team2_wins ?> wins
             <?php endif; ?>
         </th>
     </tr>


### PR DESCRIPTION
- Adds optional parameter to battle initialization
- Battles have rounds, tracks winner of each round and resets to clean state at start of next
- Winner declared if sufficient wins reached (e.g. 2 wins in a 3 round battle will skip the 3rd round)
- If tied by end of round limit, will add additional rounds until the next win
- Challenges are now set to 3 rounds
- Reputation bonus for challenges from 15% -> 5%