### PR TITLE
Enable Genjutsu barrier penalty

### DIFF
--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -28,7 +28,7 @@ class BattleManager {
     const HEAL_SOFT_CAP_RATIO = 0.65; // heal beyond soft cap only 65% as effective
     const HEAL_HARD_CAP = 0.65; // caps at 65% previous turn damage heal
 
-    const GENJUTSU_BARRIER_PENALTY = 0; // 0% reduction against Genjutsu
+    const GENJUTSU_BARRIER_PENALTY = 35; // 35% reduction against Genjutsu
 
     const ELEMENTAL_CLASH_MODIFIER = 0.20; // 20% damage loss and gain
 

--- a/classes/battle/BattleManager.php
+++ b/classes/battle/BattleManager.php
@@ -28,7 +28,7 @@ class BattleManager {
     const HEAL_SOFT_CAP_RATIO = 0.65; // heal beyond soft cap only 65% as effective
     const HEAL_HARD_CAP = 0.65; // caps at 65% previous turn damage heal
 
-    const GENJUTSU_BARRIER_PENALTY = 35; // 35% reduction against Genjutsu
+    const GENJUTSU_BARRIER_PENALTY = 37.5; // 37.5% reduction against Genjutsu (62.5% strength)
 
     const ELEMENTAL_CLASH_MODIFIER = 0.20; // 20% damage loss and gain
 


### PR DESCRIPTION
Normalize barrier strength against Genjutsu, typically set to 62.5% of Tai/Nin.
