### PR TITLE
Cloudfalre img prep

### DIFF
--- a/classes/ForbiddenSeal.php
+++ b/classes/ForbiddenSeal.php
@@ -30,6 +30,12 @@ class ForbiddenSeal {
         2 => 200,
         3 => 200,
     ];
+    const DIRECT_AVATAR_UPLOAD = [
+        0 => false,
+        1 => false,
+        2 => true,
+        3 => true,
+    ];
     /** NOTE: No need to duplicate frames, arrays are merged based on seal level **/
     const DEFAULT_AVATAR_FRAMES = [
         'avy_none' => 'none',
@@ -223,6 +229,7 @@ class ForbiddenSeal {
         public int $avatar_size,
         public int $avatar_filesize,
         public array $avatar_styles,
+        public bool $direct_avatar_upload,
 
         // Social benefits
         public int $inbox_size,
@@ -332,6 +339,7 @@ class ForbiddenSeal {
             avatar_size: self::AVATAR_SIZES[$seal_level],
             avatar_filesize: self::AVATAR_FILE_SIZES[$seal_level],
             avatar_styles: self::getAvyFrames(seal_level: $seal_level),
+            direct_avatar_upload: self::DIRECT_AVATAR_UPLOAD($seal_level),
 
             inbox_size: self::INBOX_SIZES[$seal_level],
             journal_size: self::JOURNAL_SIZES[$seal_level],

--- a/classes/ForbiddenSeal.php
+++ b/classes/ForbiddenSeal.php
@@ -339,7 +339,7 @@ class ForbiddenSeal {
             avatar_size: self::AVATAR_SIZES[$seal_level],
             avatar_filesize: self::AVATAR_FILE_SIZES[$seal_level],
             avatar_styles: self::getAvyFrames(seal_level: $seal_level),
-            direct_avatar_upload: self::DIRECT_AVATAR_UPLOAD($seal_level),
+            direct_avatar_upload: self::DIRECT_AVATAR_UPLOAD[$seal_level],
 
             inbox_size: self::INBOX_SIZES[$seal_level],
             journal_size: self::JOURNAL_SIZES[$seal_level],

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -77,6 +77,11 @@ function userSettings() {
 			$file_type = strtolower(pathinfo($target_file, PATHINFO_EXTENSION));
 			$target_file_path = $target_dir . strtolower($player->user_name) . '.' . $file_type;
 			$user_link = $system->router->base_url . '_user_imgs/' . strtolower($player->user_name) . '.' . $file_type;
+
+			// Lack permission to upload file
+			if(!$player->forbidden_seal->direct_avatar_upload) {
+				throw new RuntimeException("You do not have permission to upload avatars!");
+			}
 	
 			// Upload directory is missing, this should be manually created
             if(!is_dir($target_dir)) {

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -71,6 +71,7 @@ function userSettings() {
         $system->printMessage();
     }
 	else if (!empty($_POST['upload_avatar'])) {
+		$valid_file_types = ['gif', 'png', 'jpg'];
         try {
 			$target_dir = __DIR__ . '/../_user_imgs/';
 			$target_file = $target_dir . $system->db->clean(basename($_FILES['fileToUpload']['name']));
@@ -93,7 +94,7 @@ function userSettings() {
                 throw new RuntimeException("User upload directory is missing! Notify an administrator.");
             }
 			// Only ally gif, png and jpg file types
-			if(!in_array($file_type, ['gif', 'png', 'jpg'])) {
+			if(!in_array($file_type, $valid_file_types)) {
 				throw new RuntimeException("You may only upload gif, png and jpg images.");
 			}
 			// Check file size
@@ -106,9 +107,13 @@ function userSettings() {
 			}
 			
 			// Remove existing avatar
-			if(file_exists($target_file_path)) {
-				unlink($target_file_path);
+			foreach($valid_file_types as $type) {
+				$rem_dir = $target_dir . strtolower($player->user_name) . '.' . $file_type;
+				if(file_exists($rem_dir)) {
+					unlink($rem_dir);
+				}
 			}
+			
 			// Upload file and update user link
 			if(move_uploaded_file($_FILES['fileToUpload']['tmp_name'], $target_file_path)) {
 				$player->avatar_link = $user_link;

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -79,7 +79,7 @@ function userSettings() {
 			$user_link = $system->router->base_url . '_user_imgs/' . strtolower($player->user_name) . '.' . $file_type;
 			
 			// Limit uploads to 1/day
-			if((time() - filemtime($target_file_path)) < 86400) {
+			if(file_exists($target_file_path) && (time() - filemtime($target_file_path)) < 86400) {
 				throw new RuntimeException("You can only upload a file once per day!");
 			}
 

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -77,6 +77,11 @@ function userSettings() {
 			$file_type = strtolower(pathinfo($target_file, PATHINFO_EXTENSION));
 			$target_file_path = $target_dir . strtolower($player->user_name) . '.' . $file_type;
 			$user_link = $system->router->base_url . '_user_imgs/' . strtolower($player->user_name) . '.' . $file_type;
+			
+			// Limit uploads to 1/day
+			if((time() - filemtime($target_file_path)) < 86400) {
+				throw new RuntimeException("You can only upload a file once per day!");
+			}
 
 			// Lack permission to upload file
 			if(!$player->forbidden_seal->direct_avatar_upload) {

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -108,7 +108,7 @@ function userSettings() {
 			
 			// Remove existing avatar
 			foreach($valid_file_types as $type) {
-				$rem_dir = $target_dir . strtolower($player->user_name) . '.' . $file_type;
+				$rem_dir = $target_dir . strtolower($player->user_name) . '.' . $type;
 				if(file_exists($rem_dir)) {
 					unlink($rem_dir);
 				}

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -88,7 +88,7 @@ function userSettings() {
 			}
 			
 			// Limit uploads to 1/day
-			if($current_file_path && (time() - filemtime($current_file_path)) < 86400) {
+			if($current_file_path && (time() - filemtime($current_file_path)) < 60) {
 				throw new RuntimeException("You can only upload a file once per day!");
 			}
 

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -73,11 +73,11 @@ function userSettings() {
 	else if (!empty($_POST['upload_avatar'])) {
         try {
 			$target_dir = __DIR__ . '/../_user_imgs/';
-			$target_file = $target_dir . basename($_FILES['fileToUpload']['name']);
+			$target_file = $target_dir . $system->db->clean(basename($_FILES['fileToUpload']['name']));
 			$file_type = strtolower(pathinfo($target_file, PATHINFO_EXTENSION));
 			$target_file_path = $target_dir . strtolower($player->user_name) . '.' . $file_type;
 			$user_link = $system->router->base_url . '_user_imgs/' . strtolower($player->user_name) . '.' . $file_type;
-			
+	
 			// Upload directory is missing, this should be manually created
             if(!is_dir($target_dir)) {
                 throw new RuntimeException("User upload directory is missing! Notify an administrator.");

--- a/templates/premium/forbidden_seal.php
+++ b/templates/premium/forbidden_seal.php
@@ -105,7 +105,7 @@ function nameColorDisplay(array $name_colors): string {
             (<?= round($twinSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
             <?php if($twinSeal->direct_avatar_upload): ?>
-				Direct upload of avatar image<br />
+				Direct avatar upload<br />
 			<?php endif ?>
             Additional avatar styles
         </td>
@@ -114,7 +114,7 @@ function nameColorDisplay(array $name_colors): string {
             (<?= round($fourDragonSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
             <?php if($fourDragonSeal->direct_avatar_upload): ?>
-				Direct upload of avatar image<br />
+				Direct avatar upload<br />
 			<?php endif ?>
             Additional avatar styles
         </td>
@@ -122,7 +122,7 @@ function nameColorDisplay(array $name_colors): string {
             (<?= round($eightDeitiesSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
             <?php if($eightDeitiesSeal->direct_avatar_upload): ?>
-				Direct upload of avatar image<br />
+				Direct avatar upload<br />
 			<?php endif ?>
             Additional avatar styles
         </td>

--- a/templates/premium/forbidden_seal.php
+++ b/templates/premium/forbidden_seal.php
@@ -104,17 +104,26 @@ function nameColorDisplay(array $name_colors): string {
             <?= $twinSeal->avatar_size ?>x<?= $twinSeal->avatar_size ?>&nbsp;
             (<?= round($twinSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
+            <?php if($twinSeal->direct_avatar_upload): ?>
+                Direct upload of avatar<br />
+            <? endif ?>
             Additional avatar styles
         </td>
         <td>
             <?= $fourDragonSeal->avatar_size ?>x<?= $fourDragonSeal->avatar_size ?>&nbsp;
             (<?= round($fourDragonSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
+            <?php if($fourDragonSeal->direct_avatar_upload): ?>
+                Direct upload of avatar<br />
+            <? endif ?>
             Additional avatar styles
         </td>
         <td><?= $eightDeitiesSeal->avatar_size ?>x<?= $eightDeitiesSeal->avatar_size ?>&nbsp;
             (<?= round($eightDeitiesSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
+            <?php if($eightDeitiesSeal->direct_avatar_upload): ?>
+                Direct upload of avatar<br />
+            <? endif ?>
             Additional avatar styles
         </td>
     </tr>

--- a/templates/premium/forbidden_seal.php
+++ b/templates/premium/forbidden_seal.php
@@ -124,9 +124,6 @@ function nameColorDisplay(array $name_colors): string {
             <?php if($eightDeitiesSeal->direct_avatar_upload): ?>
 				Direct upload of avatar image<br />
 			<?php endif ?>
-            <?php if($eightDeitiesSeal->direct_avatar_upload): ?>
-                Direct upload of avatar<br />
-            <? endif ?>
             Additional avatar styles
         </td>
     </tr>

--- a/templates/premium/forbidden_seal.php
+++ b/templates/premium/forbidden_seal.php
@@ -105,8 +105,8 @@ function nameColorDisplay(array $name_colors): string {
             (<?= round($twinSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
             <?php if($twinSeal->direct_avatar_upload): ?>
-                Direct upload of avatar<br />
-            <? endif ?>
+				Direct upload of avatar image<br />
+			<?php endif ?>
             Additional avatar styles
         </td>
         <td>
@@ -114,13 +114,16 @@ function nameColorDisplay(array $name_colors): string {
             (<?= round($fourDragonSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
             <?php if($fourDragonSeal->direct_avatar_upload): ?>
-                Direct upload of avatar<br />
-            <? endif ?>
+				Direct upload of avatar image<br />
+			<?php endif ?>
             Additional avatar styles
         </td>
         <td><?= $eightDeitiesSeal->avatar_size ?>x<?= $eightDeitiesSeal->avatar_size ?>&nbsp;
             (<?= round($eightDeitiesSeal->avatar_filesize / ForbiddenSeal::ONE_MEGABYTE, 1) ?> MB)
             <br />
+            <?php if($eightDeitiesSeal->direct_avatar_upload): ?>
+				Direct upload of avatar image<br />
+			<?php endif ?>
             <?php if($eightDeitiesSeal->direct_avatar_upload): ?>
                 Direct upload of avatar<br />
             <? endif ?>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -75,6 +75,8 @@
                     <b>Avatar info:</b><br />
                     <?php if(!$player->forbidden_seal->direct_avatar_upload): ?>
                         Avatar must be hosted on another website<br />
+                    <?php else: ?>
+                        <b>WARNING:</b> You can only upload a file once per day!
                     <?php endif ?>
                     Default limit: <?=$player->getAvatarSize()?> x <?=$player->getAvatarSize()?> pixels<br />
                     Avatar can be larger than the limit, but it will be resized<br />

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -82,17 +82,18 @@
                     Avatar can be larger than the limit, but it will be resized<br />
                     Max filesize: <?=$player->getAvatarFileSizeDisplay()?><br />
                     <br />
-                    <?php if(!$player->forbidden_seal->direct_avatar_upload): ?>
-                        <form action='<?=$self_link?>' method='post'>
-                            <input type='text' name='avatar_link' value='<?=$player->avatar_link?>' style='width:250px;margin-bottom:5px;' />
-                            <input type='submit' name='change_avatar' value='Change' />
-                        </form>
-                    <?php else: ?>
+                    <?php if($player->forbidden_seal->direct_avatar_upload): ?>
                         <form action='<?=$self_link?>' method='post' enctype='multipart/form-data'>
                             <input type='file' name='fileToUpload' id='fileToUpload' />
                             <input type='submit' name='upload_avatar' value='Upload' />
                         </form>
+						<br />
+						<b>Manual File Change:</b><br />
                     <?php endif ?>
+					<form action='<?=$self_link?>' method='post'>
+						<input type='text' id='avatar_link' name='avatar_link' value='<?=$player->avatar_link?>' style='width:250px;margin-bottom:5px;' />
+						<input type='submit' name='change_avatar' value='Change' />
+					</form>
                 </div>
                 <br style='clear:both;' />
             <?php else: ?>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -83,13 +83,14 @@
                     Max filesize: <?=$player->getAvatarFileSizeDisplay()?><br />
                     <br />
                     <?php if($player->forbidden_seal->direct_avatar_upload): ?>
+						<b>Upload Avatar</b><br />
                         <form action='<?=$self_link?>' method='post' enctype='multipart/form-data'>
                             <input type='file' name='fileToUpload' id='fileToUpload' />
                             <input type='submit' name='upload_avatar' value='Upload' />
                         </form>
 						<br />
-						<b>Manual File Change:</b><br />
                     <?php endif ?>
+					<b>Change Avatar</b><br />
 					<form action='<?=$self_link?>' method='post'>
 						<input type='text' id='avatar_link' name='avatar_link' value='<?=$player->avatar_link?>' style='width:250px;margin-bottom:5px;' />
 						<input type='submit' name='change_avatar' value='Change' />

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -76,7 +76,7 @@
                     <?php if(!$player->forbidden_seal->direct_avatar_upload): ?>
                         Avatar must be hosted on another website<br />
                     <?php else: ?>
-                        <b>WARNING:</b> You can only upload a file once per day!<br />
+                        You have permission to store your avatars on our server<br />
                     <?php endif ?>
                     Default limit: <?=$player->getAvatarSize()?> x <?=$player->getAvatarSize()?> pixels<br />
                     Avatar can be larger than the limit, but it will be resized<br />

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -73,7 +73,9 @@
             <?php if(!$player->checkBan(StaffManager::BAN_TYPE_AVATAR)):?>
                 <div>
                     <b>Avatar info:</b><br />
-                    Avatar must be hosted on another website<br />
+                    <?php if(!$player->forbidden_seal->direct_avatar_upload): ?>
+                        Avatar must be hosted on another website<br />
+                    <?php endif ?>
                     Default limit: <?=$player->getAvatarSize()?> x <?=$player->getAvatarSize()?> pixels<br />
                     Avatar can be larger than the limit, but it will be resized<br />
                     Max filesize: <?=$player->getAvatarFileSizeDisplay()?><br />

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -78,10 +78,13 @@
                     Avatar can be larger than the limit, but it will be resized<br />
                     Max filesize: <?=$player->getAvatarFileSizeDisplay()?><br />
                     <br />
-                    <form action='<?=$self_link?>' method='post'>
-                        <input type='text' name='avatar_link' value='<?=$player->avatar_link?>' style='width:250px;margin-bottom:5px;' />
-                        <input type='submit' name='change_avatar' value='Change' />
-                    </form>
+                    <?php if(!$player->forbidden_seal->direct_avatar_upload): ?>
+                        <form action='<?=$self_link?>' method='post'>
+                            <input type='text' name='avatar_link' value='<?=$player->avatar_link?>' style='width:250px;margin-bottom:5px;' />
+                            <input type='submit' name='change_avatar' value='Change' />
+                        </form>
+                    <?php else: ?>
+                    <?php endif ?>
                 </div>
                 <br style='clear:both;' />
             <?php else: ?>

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -76,7 +76,7 @@
                     <?php if(!$player->forbidden_seal->direct_avatar_upload): ?>
                         Avatar must be hosted on another website<br />
                     <?php else: ?>
-                        <b>WARNING:</b> You can only upload a file once per day!
+                        <b>WARNING:</b> You can only upload a file once per day!<br />
                     <?php endif ?>
                     Default limit: <?=$player->getAvatarSize()?> x <?=$player->getAvatarSize()?> pixels<br />
                     Avatar can be larger than the limit, but it will be resized<br />

--- a/templates/settings.php
+++ b/templates/settings.php
@@ -84,6 +84,10 @@
                             <input type='submit' name='change_avatar' value='Change' />
                         </form>
                     <?php else: ?>
+                        <form action='<?=$self_link?>' method='post' enctype='multipart/form-data'>
+                            <input type='file' name='fileToUpload' id='fileToUpload' />
+                            <input type='submit' name='upload_avatar' value='Upload' />
+                        </form>
                     <?php endif ?>
                 </div>
                 <br style='clear:both;' />


### PR DESCRIPTION
Allow T2 & T3 seal users to upload avatars directly to server.

This method requires the manual creation of `_user_imgs` in the base directory of the site.
This method will accept jpg, gif and png files that meet our file size requirements and store them as `{base_url}/_user_imgs/{user_name}.{file_type}`
Subsequent uploads will overwrite the existing image to save space.

Changed to only allow uploads once per day, to help avoid server stress.